### PR TITLE
Feature/paas cf support

### DIFF
--- a/examples/webapps/hello-world-sql/src/main/webapp/db.jsp
+++ b/examples/webapps/hello-world-sql/src/main/webapp/db.jsp
@@ -39,6 +39,11 @@ deployed by brooklyn, to show <b>SQL database interactivity</b>.
 
 <%
 String url=System.getProperty("brooklyn.example.db.url");
+
+if((url == null) || (url.isEmpty())) {
+    url = System.getenv("brooklyn.example.db.url");
+}
+
 //URL should be supplied e.g. ""-Dbrooklyn.example.db.url=jdbc:mysql://localhost/visitors?user=brooklyn&password=br00k11n"
 //(note quoting needed due to ampersand)
 if (url==null) {

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/couchbase/CouchbaseNodeImpl.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/couchbase/CouchbaseNodeImpl.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.MachineProvisioningLocation;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.api.sensor.SensorEvent;
@@ -107,8 +108,8 @@ public class CouchbaseNodeImpl extends SoftwareProcessImpl implements CouchbaseN
         });
     }
 
-    protected Map<String, Object> obtainProvisioningFlags(@SuppressWarnings("rawtypes") MachineProvisioningLocation location) {
-        ConfigBag result = ConfigBag.newInstance(super.obtainProvisioningFlags(location));
+    protected Map<String, Object> obtainFlagsForLocation(@SuppressWarnings("rawtypes") Location location) {
+        ConfigBag result = ConfigBag.newInstance(super.obtainFlagsForLocation(location));
         result.configure(CloudLocationConfig.OS_64_BIT, true);
         return result.getAllConfig();
     }

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeImpl.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeImpl.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
+import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.MachineProvisioningLocation;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.entity.Entities;
@@ -91,8 +92,8 @@ public class RiakNodeImpl extends SoftwareProcessImpl implements RiakNode {
     }
 
     @Override
-    protected Map<String, Object> obtainProvisioningFlags(@SuppressWarnings("rawtypes") MachineProvisioningLocation location) {
-        ConfigBag result = ConfigBag.newInstance(super.obtainProvisioningFlags(location));
+    protected Map<String, Object> obtainFlagsForLocation(@SuppressWarnings("rawtypes") Location location) {
+        ConfigBag result = ConfigBag.newInstance(super.obtainFlagsForLocation(location));
         result.configure(CloudLocationConfig.OS_64_BIT, true);
         return result.getAllConfig();
     }

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/JavaWebAppCloudFoundryDriver.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/JavaWebAppCloudFoundryDriver.java
@@ -1,0 +1,275 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.webapp;
+
+import com.google.common.annotations.Beta;
+import com.google.common.collect.ImmutableSet;
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.entity.java.JavaSoftwareProcessDriver;
+import org.apache.brooklyn.entity.software.base.AbstractApplicationCloudFoundryDriver;
+import org.apache.brooklyn.entity.software.base.SoftwareProcess;
+import org.apache.brooklyn.location.cloudfoundry.CloudFoundryPaasLocation;
+import org.apache.brooklyn.util.http.HttpTool;
+import org.cloudfoundry.client.lib.domain.CloudApplication;
+import org.cloudfoundry.client.lib.domain.Staging;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+@Beta
+public abstract class JavaWebAppCloudFoundryDriver extends AbstractApplicationCloudFoundryDriver
+        implements JavaSoftwareProcessDriver, JavaWebAppDriver {
+
+    private static final int HTTP_PORT = 8080;
+    private static final int HTTP_PORTS = 443;
+    private static final  Set<String> ENABLED_PROTOCOLS;
+    static{
+        ENABLED_PROTOCOLS = ImmutableSet.of("http", "https");
+    }
+
+    private String applicationName;
+    private String applicationWarUrl;
+
+    public JavaWebAppCloudFoundryDriver(EntityLocal entity, CloudFoundryPaasLocation location) {
+        super(entity, location);
+    }
+
+    public JavaWebAppSoftwareProcessImpl getEntity() {
+        return (JavaWebAppSoftwareProcessImpl) super.getEntity();
+    }
+
+    @Override
+    protected void init() {
+        super.init();
+        initApplicationParameters();
+        initAttributes();
+    }
+
+    @SuppressWarnings("unchecked")
+    /**
+     * It allows to init parameters necessary for the drivers.
+     */
+    protected void initApplicationParameters() {
+        //TODO: Probably, this method could be moved to the super class.
+        //but, a new configkey should be necessary to specify the deployment
+        //artifact (war) without using the java service.
+        applicationWarUrl = getEntity().getConfig(JavaWebAppService.ROOT_WAR);
+
+        String nameWithExtension=getFilenameContextMapper()
+                .findArchiveNameFromUrl(applicationWarUrl, true);
+        applicationName  = nameWithExtension.substring(0, nameWithExtension.indexOf('.'))
+                + "-" +entity.getId();
+
+        //These values shouldn't be null or empty
+        checkNotNull(applicationWarUrl, "application war url");
+        checkNotNull(applicationName, "application name");
+    }
+
+    /**
+     * It allows to change the value to the generic entity attributes
+     * according to the PaaS constraint
+     */
+    protected void initAttributes(){
+        getEntity().setAttribute(Attributes.HTTP_PORT, HTTP_PORT);
+        getEntity().setAttribute(Attributes.HTTPS_PORT, HTTP_PORTS);
+
+        getEntity().setAttribute(WebAppServiceConstants.ENABLED_PROTOCOLS, ENABLED_PROTOCOLS);
+    }
+
+    @Override
+    public String getBuildpack(){
+        return getEntity().getBuildpack();
+    }
+
+    protected String getApplicationUrl(){
+        return applicationWarUrl;
+    }
+
+    protected String getApplicationName(){
+        return applicationName;
+    }
+
+    @Override
+    public Set<String> getEnabledProtocols() {
+        return entity.getAttribute(JavaWebAppSoftwareProcess.ENABLED_PROTOCOLS);
+    }
+
+    @Override
+    public Integer getHttpPort() {
+        return getEntity().getHttpPort();
+    }
+
+    @Override
+    public Integer getHttpsPort() {
+        return getEntity().getHttpsPort();
+    }
+
+    @Override
+    public HttpsSslConfig getHttpsSslConfig() {
+        return null;
+    }
+
+    @Override
+    public boolean isRunning() {
+        return super.isRunning() && isInferRootAvailable();
+    }
+
+    private boolean isInferRootAvailable(){
+        boolean result;
+        try {
+            result = HttpTool.getHttpStatusCode(inferRootUrl()) == HttpURLConnection.HTTP_OK ;
+        } catch (Exception e) {
+            result = false;
+        }
+        return result;
+    }
+
+    @Override
+    public void preLaunch(){
+        configureEnv();
+    }
+
+    /**
+     * It adds {@link SoftwareProcess#SHELL_ENVIRONMENT} and
+     * {@link JavaWebAppSoftwareProcess#JAVA_SYSPROPS) as envs on CF.
+     */
+    @SuppressWarnings("unchecked")
+    protected void configureEnv(){
+        Map<String,String> shellEnvProp = (Map<String,String>)(Map) getEntity().getConfig(SoftwareProcess.SHELL_ENVIRONMENT);
+        setEnv(shellEnvProp);
+        setEnv(getEntity().getConfig(JavaWebAppSoftwareProcess.JAVA_SYSPROPS));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void setEnv(Map<String, String> envs) {
+        CloudApplication app = getClient().getApplication(applicationName);
+
+        // app.setEnv() replaces the entire set of variables, so we need to add it externally.
+        Map oldEnv = app.getEnvAsMap();
+        oldEnv.putAll(envs);
+        getClient().updateApplicationEnv(applicationName, oldEnv);
+    }
+
+    @Override
+    public void postLaunch() {
+        super.postLaunch();
+        String domainUrl = inferRootUrl();
+        getEntity().setAttribute(Attributes.MAIN_URI, URI.create(domainUrl));
+        entity.setAttribute(WebAppService.ROOT_URL,  domainUrl);
+    }
+
+    protected String inferRootUrl() {
+        //TODO: this method is copied from JavaWebAppSshDriver, so it could be moved to any super class. It could be moved to the entity too
+
+        CloudApplication application = getClient().getApplication(getApplicationName());
+        String domainUri = application.getUris().get(0);
+
+        if (isProtocolEnabled("https")) {
+            Integer port = getHttpsPort();
+            checkNotNull(port, "HTTPS_PORT sensors not set; is an acceptable port available?");
+            return String.format("https://%s", domainUri);
+        } else if (isProtocolEnabled("http")) {
+            Integer port = getHttpPort();
+            checkNotNull(port, "HTTP_PORT sensors not set; is an acceptable port available?");
+            return String.format("http://%s", domainUri);
+        } else {
+            throw new IllegalStateException("HTTP and HTTPS protocols not enabled for "+entity+"; enabled protocols are "+getEnabledProtocols());
+        }
+    }
+
+    protected boolean isProtocolEnabled(String protocol) {
+        //TODO: this method is copied from JavaWebAppSshDriver, so it could be moved to any super class. . It could be moved to the entity too
+        Set<String> protocols = getEnabledProtocols();
+        for (String contender : protocols) {
+            if (protocol.equalsIgnoreCase(contender)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public void deploy() {
+        getEntity().deploy(applicationWarUrl, applicationName);
+    }
+
+    @Override
+    public void deploy(File file) {
+        deploy(file, null);
+    }
+
+    @Override
+    public void deploy(File f, String targetName) {
+        if (targetName == null) {
+            targetName = f.getName();
+        }
+        deploy(f.toURI().toASCIIString(), targetName);
+    }
+
+    @Override
+    public String deploy(String url, String targetName) {
+        List<String> uris = new ArrayList<String>();
+        Staging staging;
+        File war;
+
+        try {
+            staging = new Staging(null, getBuildpack());
+            uris.add(inferApplicationDomainUri(getApplicationName()));
+
+            war=LocalResourcesDownloader
+                    .downloadResourceInLocalDir(getApplicationUrl());
+
+            getClient().createApplication(getApplicationName(), staging,
+                    getLocation().getConfig(CloudFoundryPaasLocation.REQUIRED_MEMORY),
+                    uris, null);
+            getClient().uploadApplication(getApplicationName(), war.getCanonicalPath());
+        } catch (IOException e) {
+            log.error("Error deploying application {} managed by driver {}",
+                    new Object[]{getEntity(), this});
+        }
+
+        return targetName;
+    }
+
+    @Override
+    public void undeploy(String targetName) {
+        //TODO: complete
+    }
+
+    @Override
+    public FilenameToWebContextMapper getFilenameContextMapper() {
+        return new FilenameToWebContextMapper();
+    }
+
+    @Override
+    public boolean isJmxEnabled() {
+        return false;
+    }
+
+
+}

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/JavaWebAppSoftwareProcess.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/JavaWebAppSoftwareProcess.java
@@ -18,10 +18,21 @@
  */
 package org.apache.brooklyn.entity.webapp;
 
+import com.google.common.annotations.Beta;
+import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
+import org.apache.brooklyn.util.core.flags.SetFromFlag;
 
 public interface JavaWebAppSoftwareProcess extends SoftwareProcess, JavaWebAppService, JavaWebAppService.CanDeployAndUndeploy {
-    
+
+    //TODO:probably, this ConfigKey could be moved to the children classes
+    @SetFromFlag("buildpack")
+    ConfigKey<String> BUILDPACK= ConfigKeys.newStringConfigKey(
+            "cloudFoundryWebApp.application.buildpack", "URL of the required buildpack",
+            "https://github.com/cloudfoundry/java-buildpack.git");
+
+
     // exist on the interface for freemarker to pick it up
     
     public boolean isHttpEnabled();

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/JavaWebAppSoftwareProcessImpl.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/JavaWebAppSoftwareProcessImpl.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.annotations.Beta;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.core.annotation.Effector;
 import org.apache.brooklyn.core.annotation.EffectorParam;
@@ -201,5 +202,10 @@ public abstract class JavaWebAppSoftwareProcessImpl extends SoftwareProcessImpl 
         HttpsSslConfig config = getAttribute(HTTPS_SSL_CONFIG);
         return (config == null) ? "" : config.getKeystorePassword();
     }
+
+    public String getBuildpack() {
+        return getConfig(BUILDPACK);
+    }
+
 
 }

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/LocalResourcesDownloader.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/LocalResourcesDownloader.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.webapp;
+
+import com.google.common.base.Throwables;
+import org.apache.brooklyn.util.core.ResourceUtils;
+import org.apache.brooklyn.util.os.Os;
+import org.apache.brooklyn.util.text.Strings;
+import org.apache.commons.io.FileUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class LocalResourcesDownloader {
+    private static final String BROOKLYN_DIR="brooklyn";
+
+    public static File downloadResourceInLocalDir(String url) {
+        File localResource = createLocalFilePathName(
+                findArchiveNameFromUrl(url));
+        LocalResourcesDownloader.downloadResource(url, localResource);
+        return localResource;
+    }
+
+    /**
+     * Generates a tmp directory based on:</br>
+     * TMP_OS_DIRECTORY/brooklyn/ENTITY_ID/RANDOM_STRING(8)
+     * @return
+     */
+    public static String findATmpDir(){
+        String osTmpDir = new Os.TmpDirFinder().get().get();
+        return osTmpDir + File.separator +
+                BROOKLYN_DIR + File.separator +
+                Strings.makeRandomId(8);
+    }
+
+    public static File createLocalFilePathName(String fileName){
+        return new File(createLocalPathName(fileName));
+    }
+
+    public static String createLocalPathName(String fileName){
+        String targetDirName = LocalResourcesDownloader.findATmpDir();
+        String filePathName = targetDirName + File.separator + fileName;
+
+        File targetDir = new File(targetDirName);
+        targetDir.mkdirs();
+
+        return filePathName;
+    }
+
+    public static String findArchiveNameFromUrl(String url) {
+        String name = url.substring(url.lastIndexOf('/') + 1);
+        if (name.indexOf("?") > 0) {
+            Pattern p = Pattern.compile("[A-Za-z0-9_\\-]+\\..(ar|AR)($|(?=[^A-Za-z0-9_\\-]))");
+            Matcher wars = p.matcher(name);
+            if (wars.find()) {
+                name = wars.group();
+            }
+        }
+        return name;
+    }
+
+    public static void downloadResource(String url, File target){
+        try {
+            downloadResource(new ResourceUtils(null).getResourceFromUrl(url), target);
+        } catch (Exception e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+    public static void downloadResource(InputStream source, File target){
+        try {
+            FileUtils.copyInputStreamToFile(source, target);
+        } catch (IOException e) {
+            throw Throwables.propagate(e);
+        }
+    }
+
+
+}
+

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/tomcat/TomcatCloudFoundryDriver.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/tomcat/TomcatCloudFoundryDriver.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.webapp.tomcat;
+
+import org.apache.brooklyn.api.entity.EntityLocal;
+import org.apache.brooklyn.entity.webapp.JavaWebAppCloudFoundryDriver;
+import org.apache.brooklyn.location.cloudfoundry.CloudFoundryPaasLocation;
+
+public class TomcatCloudFoundryDriver extends JavaWebAppCloudFoundryDriver implements TomcatDriver {
+
+    public TomcatCloudFoundryDriver(EntityLocal entity, CloudFoundryPaasLocation location) {
+        super(entity, location);
+    }
+
+    @Override
+    public String getBuildpack() {
+        return getEntity().getConfig(TomcatServer.BUILDPACK);
+    }
+
+}
+

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/tomcat/TomcatServer.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/tomcat/TomcatServer.java
@@ -84,4 +84,10 @@ public interface TomcatServer extends JavaWebAppSoftwareProcess, UsesJmx, HasSho
 
     AttributeSensor<String> JMX_SERVICE_URL = UsesJmx.JMX_URL;
 
+    @SetFromFlag("buildpack")
+    ConfigKey<String> BUILDPACK= ConfigKeys.newStringConfigKey(
+            "cloudFoundryWebApp.application.buildpack", "URL of the required buildpack",
+            "https://github.com/cloudfoundry/java-buildpack.git");
+
+
 }

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/tomcat/TomcatServerImpl.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/tomcat/TomcatServerImpl.java
@@ -121,5 +121,10 @@ public class TomcatServerImpl extends JavaWebAppSoftwareProcessImpl implements T
     public String getShortName() {
         return "Tomcat";
     }
+
+    public String getBuildpack() {
+        return getConfig(TomcatServer.BUILDPACK);
+    }
+
 }
 

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/AbstractCloudFoundryPaasLocationLiveTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/AbstractCloudFoundryPaasLocationLiveTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.webapp;
+
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.internal.BrooklynProperties;
+import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
+import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
+import org.apache.brooklyn.core.test.entity.LocalManagementContextForTests;
+import org.apache.brooklyn.core.test.entity.TestApplication;
+import org.apache.brooklyn.location.cloudfoundry.CloudFoundryPaasLocation;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
+public abstract class AbstractCloudFoundryPaasLocationLiveTest extends BrooklynAppLiveTestSupport {
+
+    protected BrooklynProperties brooklynProperties;
+    protected LocalManagementContext managementContext;
+    protected CloudFoundryPaasLocation cloudFoundryPaasLocation;
+    protected final String LOCATION_SPEC_NAME = "cloudfoundry-instance";
+
+    @BeforeMethod
+    public void setUp() throws Exception {
+        managementContext = newLocalManagementContext();
+        brooklynProperties = new LocalManagementContext().getBrooklynProperties();
+        cloudFoundryPaasLocation = newSampleCloudFoundryLocationForTesting(LOCATION_SPEC_NAME);
+        app = TestApplication.Factory.newManagedInstanceForTests();
+    }
+
+    protected LocalManagementContext newLocalManagementContext() {
+        return new LocalManagementContextForTests(BrooklynProperties.Factory.newDefault());
+    }
+
+    @AfterMethod
+    public void tearDown() throws Exception {
+        if (app != null) {
+            Entities.destroyAllCatching(app.getManagementContext());
+        }
+        if (managementContext != null){
+            Entities.destroyAll(managementContext);
+        }
+    }
+
+    protected CloudFoundryPaasLocation newSampleCloudFoundryLocationForTesting(String spec) {
+        return (CloudFoundryPaasLocation) managementContext.getLocationRegistry().resolve(spec);
+    }
+
+    public String getClasspathUrlForResource(String resourceName){
+        return "classpath://"+ resourceName;
+    }
+
+
+}

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/tomcat/TomcatCloudFoundryLiveTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/tomcat/TomcatCloudFoundryLiveTest.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.entity.webapp.tomcat;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
+import org.apache.brooklyn.core.entity.trait.Startable;
+import org.apache.brooklyn.entity.software.base.SoftwareProcess;
+import org.apache.brooklyn.entity.webapp.AbstractCloudFoundryPaasLocationLiveTest;
+import org.apache.brooklyn.entity.webapp.WebAppService;
+import org.apache.brooklyn.entity.webapp.WebAppServiceConstants;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.exceptions.PropagatedRuntimeException;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+@Test(groups = {"Live"})
+public class TomcatCloudFoundryLiveTest extends AbstractCloudFoundryPaasLocationLiveTest {
+
+    private final String APPLICATION_ARTIFACT_NAME = "hello-world.war";
+
+    private final String APPLICATION_ARTIFACT_URL =
+            getClasspathUrlForResource(APPLICATION_ARTIFACT_NAME);
+
+    public void deployApplicationTest() throws Exception {
+        final TomcatServer server = app.
+                createAndManageChild(EntitySpec.create(TomcatServer.class)
+                        .configure("wars.root", APPLICATION_ARTIFACT_URL)
+                        .location(cloudFoundryPaasLocation));
+
+        app.start(ImmutableList.of(cloudFoundryPaasLocation));
+
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                assertTrue(server.getAttribute(Startable.SERVICE_UP));
+                assertTrue(server.getAttribute(SoftwareProcess
+                        .SERVICE_PROCESS_IS_RUNNING));
+
+                assertNotNull(server.getAttribute(Attributes.MAIN_URI));
+                assertNotNull(server.getAttribute(WebAppService.ROOT_URL));
+                assertEquals(server.getAttribute(WebAppServiceConstants.ENABLED_PROTOCOLS).size(), 2);
+                assertTrue(server.isHttpEnabled());
+                assertTrue(server.isHttpsEnabled());
+                assertEquals(server.getHttpPort(), new Integer(8080));
+                assertEquals(server.getHttpsPort(), new Integer(443));
+
+            }
+        });
+    }
+
+    public void wrongApplicationOnFireStatusTest() throws Exception {
+        final TomcatServer server = app.
+                createAndManageChild(EntitySpec.create(TomcatServer.class)
+                        .configure("wars.root", APPLICATION_ARTIFACT_URL + "wrong")
+                        .location(cloudFoundryPaasLocation));
+
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                try {
+                    app.start(ImmutableList.of(cloudFoundryPaasLocation));
+                } catch (PropagatedRuntimeException e) {
+                    assertEquals(server.getAttribute(TomcatServer.SERVICE_STATE_ACTUAL),
+                            Lifecycle.ON_FIRE);
+                }
+            }
+        });
+    }
+
+    public void stopApplicationTest() throws Exception {
+        final TomcatServer server = app.
+                createAndManageChild(EntitySpec.create(TomcatServer.class)
+                        .configure("wars.root", APPLICATION_ARTIFACT_URL)
+                        .location(cloudFoundryPaasLocation));
+
+        app.start(ImmutableList.of(cloudFoundryPaasLocation));
+
+        Asserts.succeedsEventually(new Runnable() {
+            public void run() {
+                assertTrue(server.getAttribute(Startable.SERVICE_UP));
+
+                app.stop();
+                assertEquals(server.getAttribute(TomcatServer
+                        .SERVICE_STATE_ACTUAL), Lifecycle.STOPPED);
+                assertFalse(server.getAttribute(Startable.SERVICE_UP));
+                assertFalse(server.getAttribute(TomcatServer
+                        .SERVICE_PROCESS_IS_RUNNING));
+            }
+        });
+    }
+
+
+}
+


### PR DESCRIPTION
This commit depends on [brooklyn-server#30](https://github.com/apache/brooklyn-server/pull/30)
Adding PaaS CloudFoundry support to `TomcatServer` entity.

The drivers for CloudFoundry are added to `SoftwareProcess` entity and `JavaWebAppSoftwareProcess` implementation entity. 
The final PaaS support is added to `TomcatServer` entity using a new driver which is focused on `CloudFoundryPaaSLocation`.

Then, `TomcatServer` can be started in a Ssh location or in a CloudFoundryLocation.

For example, the following `hello-world-sql` application has a TomcatServer.

```
name: appserver-web-aws
services:
- type: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
  name: AppServer HelloWorld
  location: <LOCATION>
  brooklyn.config:
    wars.root: https://github.com/kiuby88/brooklyn-library/releases/download/hello-world-sql-paas/brooklyn-example-hello-world-sql-webapp-in-paas.war
    http.port: 8080+
    java.sysprops: 
      brooklyn.example.db.url: $brooklyn:formatString("jdbc:%s%s?user=%s&password=%s",
         component("db").attributeWhenReady("datastore.url"), "visitors", "brooklyn", "br00k11n")

- type: org.apache.brooklyn.entity.database.mysql.MySqlNode
  id: db
  location: aws-ec2:us-west-2
  name: DB HelloWorld Visitors
  brooklyn.config:
    datastore.creation.script.url: https://raw.githubusercontent.com/apache/incubator-brooklyn/master/brooklyn-server/launcher/src/test/resources/visitors-creation-script.sql
```

`TomcatServer`'s location can contains a Ssh- or CloudFoundry-based location. If `<LOCATION>` is equals to e.g., `aws-ec2:us-west-2, TomcatServer will be deployed on AWS Oregon.
But, it <LOCATION> is a CloudFoundry-based location, for example [Pivotal](https://run.pivotal.io/):

```
  location:
    cloudfoundry:
      user: <user>
      password: <pass>
      org: <org>
      endpoint: https://api.run.pivotal.io
      space: <space>
      address: run.pivotal.io
```

`TomcatServer` entity will be deployed using Pivotal Web Services.

Please, note that the yaml is the same for deploying the application on Ssh or CloudFoundry. 
#### Tested Providers

This approach has been tested using:
- [Pivotal](https://run.pivotal.io/)
- [Bluemix](https://console.ng.bluemix.net/)
#### RoadMap

This is a first approach. If it is accepted a lot of entities could be enabled to operate on CloudFoundry.
