### PR TITLE
Validation of blueprint projects

### DIFF
--- a/brooklyn-validations/pom.xml
+++ b/brooklyn-validations/pom.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>brooklyn-library</artifactId>
+        <groupId>org.apache.brooklyn</groupId>
+        <version>0.9.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>brooklin-validations</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-utils-common</artifactId>
+            <version>0.9.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>${testng.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.findbugs</groupId>
+            <artifactId>jsr305</artifactId>
+            <version>${jsr305.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-utils-test-support</artifactId>
+            <version>0.9.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+
+    <build>
+        <testSourceDirectory>src/test/java</testSourceDirectory>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+            </testResource>
+        </testResources>
+
+
+        <pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>${surefire.version}</version>
+                <configuration>
+                    <properties>
+                        <property>
+                            <name>listener</name>
+                            <value>org.apache.brooklyn.test.support.LoggingVerboseReporter</value>
+                        </property>
+                    </properties>
+                    <enableAssertions>true</enableAssertions>
+                    <groups>${includedTestGroups}</groups>
+                    <excludedGroups>${excludedTestGroups}</excludedGroups>
+                    <testFailureIgnore>false</testFailureIgnore>
+                    <systemPropertyVariables>
+                        <verbose>-1</verbose>
+                        <net.sourceforge.cobertura.datafile>${project.build.directory}/cobertura/cobertura.ser</net.sourceforge.cobertura.datafile>
+                        <cobertura.user.java.nio>false</cobertura.user.java.nio>
+                    </systemPropertyVariables>
+                    <printSummary>true</printSummary>
+                </configuration>
+            </plugin>
+        </plugins>
+        </pluginManagement>
+    </build>
+
+</project>

--- a/brooklyn-validations/src/main/java/org/apache/brooklyn/validations/catalog/Catalog.java
+++ b/brooklyn-validations/src/main/java/org/apache/brooklyn/validations/catalog/Catalog.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.validations.catalog;
+
+import com.google.common.base.Function;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import java.util.List;
+import java.util.Map;
+
+public class Catalog {
+
+    private final Map<String, CatalogProject> catalogProjects;
+
+    public Catalog(Map<String, CatalogProject> catalogProjects) {
+        this.catalogProjects = catalogProjects;
+    }
+
+    public List<CatalogProject> getCatalogProjects() {
+        return ImmutableList.copyOf(catalogProjects.values());
+    }
+
+    public Map<String, CatalogProject> getCatalogProjectsMap() {
+        return catalogProjects;
+    }
+
+    public List<Repository> getRepositories() {
+        return Lists.transform(getCatalogProjects(), new Function<CatalogProject, Repository>() {
+            public Repository apply(CatalogProject input) {
+                return input.getRepository();
+            }
+        });
+    }
+
+    public CatalogProject getCatalogProject(String ownerName, String repoName) {
+        String token = ownerName + "/" + repoName;
+        return catalogProjects.get(token);
+    }
+}

--- a/brooklyn-validations/src/main/java/org/apache/brooklyn/validations/catalog/CatalogProject.java
+++ b/brooklyn-validations/src/main/java/org/apache/brooklyn/validations/catalog/CatalogProject.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.validations.catalog;
+
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.apache.brooklyn.util.yaml.Yamls;
+
+import javax.annotation.Nullable;
+import java.util.Map;
+
+public class CatalogProject {
+
+    private final Repository repository;
+
+    private final String description;
+
+    private final String catalogBomString;
+    private final Map<String, Object> catalogBomYaml;
+
+    private final String documentation;
+    private final String masterCommitHash;
+    private final String license;
+    private final String changelog;
+
+    private final boolean isValid;
+
+    @SuppressWarnings("unchecked")
+    public CatalogProject(String repoUrl, String repoName, String author, String description,
+                          String catalogBomString, Map<String, Object> catalogBomYaml, @Nullable String documentation,
+                          @Nullable String masterCommitHash, @Nullable String license, @Nullable String changelog) {
+
+        this.repository = new Repository(repoUrl, repoName, author);
+
+        this.description = description;
+
+        this.catalogBomString = catalogBomString;
+        this.catalogBomYaml = catalogBomYaml;
+
+        this.documentation = documentation;
+        this.masterCommitHash = masterCommitHash;
+        this.license = license;
+        this.changelog = changelog;
+
+        this.isValid = true;
+    }
+
+    public CatalogProject(String repoUrl, String repoName, String author) {
+
+        this.repository = new Repository(repoUrl, repoName, author);
+
+        this.description = "";
+
+        this.catalogBomString = "";
+        this.catalogBomYaml = MutableMap.of();
+
+        this.documentation = "";
+        this.masterCommitHash = "";
+        this.license = "";
+        this.changelog = "";
+
+        this.isValid = false;
+    }
+
+    public Repository getRepository() {
+        return repository;
+    }
+
+    public String getToken() {
+        return getRepository().getToken();
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public String getCatalogBomString() {
+        return catalogBomString;
+    }
+
+    public Map<String, Object> getCatalogBomYaml() {
+        return catalogBomYaml;
+    }
+
+    public String getDocumentation() {
+        return documentation;
+    }
+
+    public String getMasterCommitHash() {
+        return masterCommitHash;
+    }
+
+    public String getLicense() {
+        return license;
+    }
+
+    public String getChangelog() {
+        return changelog;
+    }
+
+    public boolean isValid() {
+        return isValid;
+    }
+
+}

--- a/brooklyn-validations/src/main/java/org/apache/brooklyn/validations/catalog/CatalogScraper.java
+++ b/brooklyn-validations/src/main/java/org/apache/brooklyn/validations/catalog/CatalogScraper.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.validations.catalog;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Maps;
+import org.apache.brooklyn.util.yaml.Yamls;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+
+public class CatalogScraper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CatalogScraper.class);
+
+    public static Catalog scrapeCatalog(String repoUrl) {
+        List<String> catalogProjectRepoUrls = parseDirectoryYaml(repoUrl);
+        Map<String, CatalogProject> scrapedCatalogProjects = Maps.newHashMapWithExpectedSize(catalogProjectRepoUrls
+                .size());
+
+        for (String catalogProjectRepoUrl : catalogProjectRepoUrls) {
+            Optional<CatalogProject> catalogProject = parseCatalogProject(catalogProjectRepoUrl);
+
+            if (catalogProject.isPresent()) {
+                scrapedCatalogProjects.put(catalogProject.get().getToken(), catalogProject.get());
+            }
+        }
+
+        LOG.info("Scraping complete");
+
+        return new Catalog(scrapedCatalogProjects);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<String> parseDirectoryYaml(String repoUrl) {
+        Optional<String> directoryYamlString;
+        try {
+            directoryYamlString = CatalogScraperHelper.getGithubRawText(repoUrl, "directory.yaml", true);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to load blueprint catalog.", e);
+        }
+
+        return (List) Yamls.parseAll(directoryYamlString.get()).iterator().next();
+    }
+
+    public static Optional<CatalogProject> parseCatalogProject(String repoUrl) {
+        String[] urlTokens = repoUrl.split("/");
+        String repoName = urlTokens[urlTokens.length - 1];
+        String author = urlTokens[urlTokens.length - 2];
+
+        try {
+            Optional<String> description = CatalogScraperHelper.getGithubRawText(repoUrl, "README.md",
+                    true);
+
+            Optional<String> catalogBomString = CatalogScraperHelper.getGithubRawText(repoUrl,
+                    "catalog.bom", true);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> catalogBomYaml = (Map<String, Object>) Yamls.parseAll(catalogBomString.get())
+                    .iterator().next();
+
+            Optional<String> documentation = CatalogScraperHelper.getGithubRawText(repoUrl, "items.js",
+                    false);
+
+            Optional<String> masterCommitHash = Optional.absent();
+
+            Optional<String> license = Optional.absent();
+            String licenseUrl = CatalogScraperHelper.generateRawGithubUrl(repoUrl, "LICENSE.txt");
+
+            if (urlExists(licenseUrl)) {
+                license = CatalogScraperHelper.getGithubRawText(repoUrl, "LICENSE.txt", false);
+            }
+
+            Optional<String> changelog = Optional.absent();
+            String changelogUrl = CatalogScraperHelper.generateRawGithubUrl(repoUrl, "CHANGELOG.md");
+
+            if (urlExists(changelogUrl)) {
+                changelog = CatalogScraperHelper.getGithubRawText(repoUrl, "CHANGELOG.md", false);
+            }
+
+            CatalogProject catalogProject = new CatalogProject(repoUrl, repoName, author, description.get(),
+                    catalogBomString.get(), catalogBomYaml, documentation.orNull(), masterCommitHash.orNull(),
+                    license.orNull(), changelog.orNull());
+
+            return Optional.of(catalogProject);
+        } catch (IllegalStateException e) {
+            CatalogProject catalogProject = new CatalogProject(repoUrl, repoName, author);
+            return Optional.of(catalogProject);
+        } catch (Exception e) {
+            LOG.warn("Failed to parse catalog item repository: '" + repoUrl + "'.", e);
+            return Optional.absent();
+        }
+    }
+
+    private static boolean urlExists(String url) {
+        try {
+            new URL(url).openConnection().connect();
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+}

--- a/brooklyn-validations/src/main/java/org/apache/brooklyn/validations/catalog/CatalogScraperHelper.java
+++ b/brooklyn-validations/src/main/java/org/apache/brooklyn/validations/catalog/CatalogScraperHelper.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.validations.catalog;
+
+import com.google.common.base.Optional;
+import org.apache.brooklyn.util.stream.Streams;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.InputStream;
+import java.net.URL;
+
+public class CatalogScraperHelper {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CatalogScraperHelper.class);
+
+    public static Optional<String> getGithubRawText(String repoUrl, String fileName, boolean required) {
+        String rawGithubUrl = generateRawGithubUrl(repoUrl, fileName);
+
+        try (InputStream inputStream = new URL(rawGithubUrl).openStream()) {
+            return Optional.of(Streams.readFullyString(inputStream));
+        } catch (Exception e) {
+            String errorMsg = "File: '" + fileName + "' could not be read from repository: '" + repoUrl
+                    + "'.";
+
+            if (required) {
+                throw new IllegalStateException(errorMsg, e);
+            } else {
+                LOG.info(errorMsg);
+                return Optional.absent();
+            }
+        }
+    }
+
+    public static String generateRawGithubUrl(String repoUrl, String fileName) {
+        return repoUrl.replace("github.com", "raw.githubusercontent.com") + "/master/" + fileName;
+    }
+}

--- a/brooklyn-validations/src/main/java/org/apache/brooklyn/validations/catalog/Repository.java
+++ b/brooklyn-validations/src/main/java/org/apache/brooklyn/validations/catalog/Repository.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.validations.catalog;
+
+public class Repository {
+
+    private final String repoUrl;
+    private final String repoName;
+    private final String author;
+    private final String token;
+
+    public Repository(String repoUrl, String repoName, String author) {
+        this.repoUrl = repoUrl;
+        this.repoName = repoName;
+        this.author = author;
+        this.token = author + "/" + repoName;
+    }
+
+    public String getRepoUrl() {
+        return repoUrl;
+    }
+
+    public String getRepoName() {
+        return repoName;
+    }
+
+    public String getAuthor() {
+        return author;
+    }
+
+    public String getToken() {
+        return token;
+    }
+}

--- a/brooklyn-validations/src/test/java/org/apache/brooklyn/validations/catalog/CatalogValidationTest.java
+++ b/brooklyn-validations/src/test/java/org/apache/brooklyn/validations/catalog/CatalogValidationTest.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.brooklyn.validations.catalog;
+
+import com.google.common.base.Optional;
+import org.apache.brooklyn.test.Asserts;
+import org.apache.brooklyn.util.collections.MutableMap;
+import org.testng.annotations.Test;
+
+import java.util.Map;
+
+public class CatalogValidationTest {
+
+
+    private String REPO_URL = "https://github.com/brooklyncentral/brooklyn-community-catalog";
+    private String NOT_VALID_REPO_URL = "https://github.com/iyovcheva/brooklyn-community-catalog";
+
+    private String VALID_CTALOG_URL = "https://github.com/cloudsoft/jmeter-entity";
+    private String NOT_VALID_CTALOG_URL = "https://github.com/cloudsoft/bower-cloudsoft-ui-common";
+
+    @Test
+    public void testCatalogProjectValidation() {
+        String validationResult = validateCatalogRepos(REPO_URL);
+        Asserts.assertEquals(validationResult, "", validationResult);
+
+        String validationResultNotValidRepo = validateCatalogRepos(NOT_VALID_REPO_URL);
+        Asserts.assertFalse(validationResultNotValidRepo.isEmpty(), "Not valid repo was successfully validated");
+    }
+
+    @Test
+    public void testSingleCatalogValidation() {
+        Asserts.assertTrue(validateCatalogRepo(VALID_CTALOG_URL), "Catalog  " + VALID_CTALOG_URL + " is not valid.");
+        Asserts.assertFalse(validateCatalogRepo(NOT_VALID_CTALOG_URL), "Not valid catalog " + NOT_VALID_CTALOG_URL + " is successfully validated.");
+    }
+
+    private String validateCatalogRepos(String repo) {
+        Catalog catalog = CatalogScraper.scrapeCatalog(repo);
+        Map<String, Boolean> validatedCatalogProjects = validateRepos(catalog.getCatalogProjectsMap());
+        String result = "";
+        for (Map.Entry repoUrl: validatedCatalogProjects.entrySet()) {
+            if (repoUrl.getValue().equals(false)) {
+                result = result.concat(repoUrl.getKey() + " is not valid catalog\n");
+            }
+        }
+        return result;
+    }
+
+    private Map<String, Boolean> validateRepos(Map<?,?> repoUrls) {
+        Map<String, Boolean> result = MutableMap.of();
+        for (Map.Entry repo: repoUrls.entrySet()) {
+            result.put((String) repo.getKey(), ((CatalogProject)repo.getValue()).isValid());
+        }
+        return result;
+    }
+
+    private boolean validateCatalogRepo(String repo) {
+        Optional<CatalogProject> catalogProject = CatalogScraper.parseCatalogProject(repo);
+        return catalogProject.get().isValid();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
         <module>qa</module>
         
         <module>examples</module>
+        <module>brooklyn-validations</module>
 
     </modules>
 


### PR DESCRIPTION
Every time `CatalogValidationTest ` is being run it will validate the manually set `REPO_URL` which is now `https://github.com/brooklyncentral/brooklyn-community-catalog`. If there is a new catalog added to `brooklyn-community-catalog`, which cannot be successfully validated, the test will fail with message: 
*"\<catalog-name/ur\> is not valid catalog"*. 

To validate a new catalog before adding it to `brooklyn-community-catalog` one can run only `CatalogValidationTest.testSingleCatalogValidation()` and change `VALID_CTALOG_URL` with its url.
