### PR TITLE
CouchDB polling sensors fix

### DIFF
--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/couchdb/CouchDBNodeImpl.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/couchdb/CouchDBNodeImpl.java
@@ -65,21 +65,21 @@ public class CouchDBNodeImpl extends SoftwareProcessImpl implements CouchDBNode 
         connectServiceUpIsRunning();
 
         boolean retrieveUsageMetrics = getConfig(RETRIEVE_USAGE_METRICS);
-        
+
         httpFeed = HttpFeed.builder()
                 .entity(this)
                 .period(500, TimeUnit.MILLISECONDS)
                 .baseUri(String.format("http://%s:%d/_stats", getAttribute(HOSTNAME), getHttpPort()))
                 .poll(new HttpPollConfig<Integer>(REQUEST_COUNT)
-                        .onSuccess(HttpValueFunctions.jsonContents(new String[] { "httpd", "requests", "count" }, Integer.class))
+                        .onSuccess(HttpValueFunctions.jsonContents(new String[] { "httpd", "requests", "sum" }, Integer.class))
                         .onFailureOrException(EntityFunctions.attribute(this, REQUEST_COUNT))
                         .enabled(retrieveUsageMetrics))
                 .poll(new HttpPollConfig<Integer>(ERROR_COUNT)
-                        .onSuccess(HttpValueFunctions.jsonContents(new String[] { "httpd_status_codes", "404", "count" }, Integer.class))
+                        .onSuccess(HttpValueFunctions.jsonContents(new String[] { "httpd_status_codes", "404", "sum" }, Integer.class))
                         .onFailureOrException(Functions.constant(-1))
                         .enabled(retrieveUsageMetrics))
                 .poll(new HttpPollConfig<Integer>(TOTAL_PROCESSING_TIME)
-                        .onSuccess(HttpValueFunctions.jsonContents(new String[] { "couchdb", "request_time", "count" }, Integer.class))
+                        .onSuccess(HttpValueFunctions.jsonContents(new String[] { "couchdb", "request_time", "sum" }, Integer.class))
                         .onFailureOrException(Functions.constant(-1))
                         .enabled(retrieveUsageMetrics))
                 .poll(new HttpPollConfig<Integer>(MAX_PROCESSING_TIME)


### PR DESCRIPTION
- update with stats which are more likely to be available

This PR is made because for version 1.2.1 on CentOS there is no count stats.
I hope that sum should be always available. It is very similar to the count field.

https://wiki.apache.org/couchdb/Runtime_Statistics