### PR TITLE
Define MAIN_URI inside SolrServer

### DIFF
--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/solr/SolrServer.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/solr/SolrServer.java
@@ -18,12 +18,15 @@
  */
 package org.apache.brooklyn.entity.nosql.solr;
 
+import java.net.URI;
 import java.util.Map;
 
 import org.apache.brooklyn.api.catalog.Catalog;
 import org.apache.brooklyn.api.entity.ImplementedBy;
+import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
+import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.location.PortRanges;
 import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey;
@@ -73,6 +76,8 @@ public interface SolrServer extends SoftwareProcess, UsesJava, UsesJmx, UsesJava
             Maps.<String, String>newHashMap());
 
     ConfigKey<Duration> START_TIMEOUT = ConfigKeys.newConfigKeyWithDefault(BrooklynConfigKeys.START_TIMEOUT, Duration.FIVE_MINUTES);
+
+    AttributeSensor<URI> MAIN_URI = Attributes.MAIN_URI;
 
     /* Accessors used from template */
 

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/solr/SolrServerImpl.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/solr/SolrServerImpl.java
@@ -55,7 +55,7 @@ public class SolrServerImpl extends SoftwareProcessImpl implements SolrServer {
         HostAndPort hp = BrooklynAccessUtils.getBrooklynAccessibleAddress(this, getSolrPort());
 
         String solrUri = String.format("http://%s:%d/solr", hp.getHostText(), hp.getPort());
-        sensors().set(Attributes.MAIN_URI, URI.create(solrUri));
+        sensors().set(MAIN_URI, URI.create(solrUri));
 
         httpFeed = HttpFeed.builder()
                 .entity(this)


### PR DESCRIPTION
I made this change in order to be accessible when listing the static fields of SolrServer for other extensions, like transformers.
@aledsage Can you review