### PR TITLE
Add creation of /etc/ansible hosts during install.

### DIFF
--- a/software/cm/ansible/src/main/java/org/apache/brooklyn/entity/cm/ansible/AnsibleLifecycleEffectorTasks.java
+++ b/software/cm/ansible/src/main/java/org/apache/brooklyn/entity/cm/ansible/AnsibleLifecycleEffectorTasks.java
@@ -118,7 +118,7 @@ public class AnsibleLifecycleEffectorTasks extends MachineLifecycleEffectorTasks
         }
 
         DynamicTasks.queue(AnsiblePlaybookTasks.installAnsible(installDir, false));
-        DynamicTasks.queue(AnsiblePlaybookTasks.setUpHostsFile(installDir, false));
+        DynamicTasks.queue(AnsiblePlaybookTasks.setUpHostsFile(false));
 
         if (getExtraVars() != null) {
             DynamicTasks.queue(AnsiblePlaybookTasks.configureExtraVars(getRunDir(), extraVars, false));

--- a/software/cm/ansible/src/main/java/org/apache/brooklyn/entity/cm/ansible/AnsibleLifecycleEffectorTasks.java
+++ b/software/cm/ansible/src/main/java/org/apache/brooklyn/entity/cm/ansible/AnsibleLifecycleEffectorTasks.java
@@ -118,6 +118,7 @@ public class AnsibleLifecycleEffectorTasks extends MachineLifecycleEffectorTasks
         }
 
         DynamicTasks.queue(AnsiblePlaybookTasks.installAnsible(installDir, false));
+        DynamicTasks.queue(AnsiblePlaybookTasks.setUpHostsFile(installDir, false));
 
         if (getExtraVars() != null) {
             DynamicTasks.queue(AnsiblePlaybookTasks.configureExtraVars(getRunDir(), extraVars, false));

--- a/software/cm/ansible/src/main/java/org/apache/brooklyn/entity/cm/ansible/AnsiblePlaybookTasks.java
+++ b/software/cm/ansible/src/main/java/org/apache/brooklyn/entity/cm/ansible/AnsiblePlaybookTasks.java
@@ -108,26 +108,12 @@ public class AnsiblePlaybookTasks {
         return " --extra-vars \"@" + EXTRA_VARS_FILENAME + "\" ";
     }
 
-    public static TaskFactory<?> setUpHostsFile(String installDir, boolean force) {
-        final String hostsFile = "/etc/ansible/hosts";
-        final String tempFile = "/tmp/hosts";
-        String checkInstalled = !force ? "which ansible || " : "";
-        return sshCommands(
-                checkInstalled + " {",
-                sudo("rm -f " + hostsFile),
-                "echo 'localhost ansible_connection=local' > " + tempFile,
-                sudo("mv " + tempFile + " " + hostsFile),
-                "}"
-            )
+    public static TaskFactory<?> setUpHostsFile(boolean force) {
+        String checkInstalled = !force ? "grep localhost.ansible_connection=local /etc/ansible/hosts || " : "";
+        return ssh(checkInstalled + sudo("echo 'localhost ansible_connection=local' | sudo tee /etc/ansible/hosts"))
             .requiringExitCodeZero()
             .summary("write hosts file");
     }
 
-
-    public static SshEffectorTasks.SshEffectorTaskFactory<Integer> sshCommands(String line, String... lines) {
-        final MutableList.Builder<String> builder = MutableList.<String>builder().add(line);
-        builder.addAll(lines);
-        return ssh(Strings.join(builder.build(), "\n"));
-    }
 }
 


### PR DESCRIPTION
This allows replacement of the command form

   ansible-playbook -i \"localhost,\" -c local  whatever

 with

   ansible-playbook whatever

 and also supports the possibility that playbooks can modify the hosts file e.g. by adding additional groups that included roles require.

 For example the following playbook modifies the hosts to add a tomcat-server group, in order to install an example ansible from the github examples repo.
```yaml
 name: multi
 location:
   red1
 services:
 - serviceType: brooklyn.entity.basic.SameServerEntity
   name: Entities
   brooklyn.children:

   - serviceType: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
     id: bootstrap
     service.name: crond
     playbook: bootstrap
     playbook.yaml: |
         ---
         - hosts: localhost
           tasks:
           - shell: printf "[tomcat-servers]\nlocalhost ansible_connection=local\n" >> /etc/ansible/hosts
           - file: path=/etc/ansible/playbooks state=directory mode=0755
           - get_url: url=https://github.com/ansible/ansible-examples/archive/master.zip dest=/tmp/master.zip mode=0440
           - command: unzip -o -d /etc/ansible/playbooks /tmp/master.zip

   - serviceType: org.apache.brooklyn.entity.stock.BasicApplication
     start.latch: $brooklyn:component("bootstrap").attributeWhenReady("service.isUp")
     brooklyn.children:
     - type: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
       name: test
       service.name: tomcat
       playbook: tomcat
       playbook.yaml: |
           ---
           - hosts: localhost
           - include: /etc/ansible/playbooks/ansible-examples-master/tomcat-standalone/site.yml
             vars:
                 http_port: 8080
                 https_port: 8443
                 admin_username: admin
                 admin_password: secret
```