### PR TITLE
Fix: ElasticSearch advertise datastore url

### DIFF
--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/elasticsearch/ElasticSearchNodeImpl.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/elasticsearch/ElasticSearchNodeImpl.java
@@ -70,7 +70,11 @@ public class ElasticSearchNodeImpl extends SoftwareProcessImpl implements Elasti
     protected void connectSensors() {
         super.connectSensors();
         Integer rawPort = getAttribute(HTTP_PORT);
+        String hostname = getAttribute(HOSTNAME);
         checkNotNull(rawPort, "HTTP_PORT sensors not set for %s; is an acceptable port available?", this);
+        
+        sensors().set(DATASTORE_URL, String.format("http://%s:%s", hostname, rawPort));
+        
         HostAndPort hp = BrooklynAccessUtils.getBrooklynAccessibleAddress(this, rawPort);
         Function<Maybe<JsonElement>, String> getNodeId = new Function<Maybe<JsonElement>, String>() {
             @Override public String apply(Maybe<JsonElement> input) {
@@ -80,7 +84,7 @@ public class ElasticSearchNodeImpl extends SoftwareProcessImpl implements Elasti
                 return input.get().getAsJsonObject().entrySet().iterator().next().getKey();
             }
         };
-        
+
         if (isHttpMonitoringEnabled()) {
             boolean retrieveUsageMetrics = getConfig(RETRIEVE_USAGE_METRICS);
 

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/elasticsearch/ElasticSearchClusterIntegrationTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/elasticsearch/ElasticSearchClusterIntegrationTest.java
@@ -28,12 +28,12 @@ import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
 import org.apache.brooklyn.entity.group.DynamicCluster;
 import org.apache.brooklyn.feed.http.HttpValueFunctions;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.http.HttpTool;
 import org.apache.brooklyn.util.http.HttpToolResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -49,6 +49,7 @@ import com.google.common.collect.ImmutableMap;
 public class ElasticSearchClusterIntegrationTest extends BrooklynAppLiveTestSupport {
 
     // FIXME Exception in thread "main" java.lang.UnsupportedClassVersionError: org/elasticsearch/bootstrap/Elasticsearch : Unsupported major.minor version 51.0
+    // Happens if PATH points at a java that is older than Java 1.7.
 
     private static final Logger LOG = LoggerFactory.getLogger(ElasticSearchClusterIntegrationTest.class);
 
@@ -68,11 +69,11 @@ public class ElasticSearchClusterIntegrationTest extends BrooklynAppLiveTestSupp
                 .configure(DynamicCluster.INITIAL_SIZE, 3));
         app.start(ImmutableList.of(testLocation));
         
-        EntityTestUtils.assertAttributeEqualsEventually(elasticSearchCluster, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(elasticSearchCluster, Startable.SERVICE_UP, true);
         
         elasticSearchCluster.stop();
         
-        EntityTestUtils.assertAttributeEqualsEventually(elasticSearchCluster, Startable.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(elasticSearchCluster, Startable.SERVICE_UP, false);
     }
     
     @Test(groups = {"Integration"})
@@ -81,7 +82,7 @@ public class ElasticSearchClusterIntegrationTest extends BrooklynAppLiveTestSupp
                 .configure(DynamicCluster.INITIAL_SIZE, 3));
         app.start(ImmutableList.of(testLocation));
         
-        EntityTestUtils.assertAttributeEqualsEventually(elasticSearchCluster, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(elasticSearchCluster, Startable.SERVICE_UP, true);
         assertEquals(elasticSearchCluster.getMembers().size(), 3);
         assertEquals(clusterDocumentCount(), 0);
         

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/elasticsearch/ElasticSearchNodeIntegrationTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/elasticsearch/ElasticSearchNodeIntegrationTest.java
@@ -19,6 +19,8 @@
 package org.apache.brooklyn.entity.nosql.elasticsearch;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -31,9 +33,12 @@ import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.feed.http.HttpValueFunctions;
+import org.apache.brooklyn.test.Asserts;
 import org.apache.brooklyn.test.EntityTestUtils;
+import org.apache.brooklyn.util.http.HttpAsserts;
 import org.apache.brooklyn.util.http.HttpTool;
 import org.apache.brooklyn.util.http.HttpToolResponse;
+import org.apache.brooklyn.util.net.Networking;
 import org.apache.http.client.methods.HttpGet;
 import org.bouncycastle.util.Strings;
 import org.testng.annotations.AfterMethod;
@@ -43,6 +48,7 @@ import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocati
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.net.HostAndPort;
 
 public class ElasticSearchNodeIntegrationTest {
     
@@ -65,8 +71,11 @@ public class ElasticSearchNodeIntegrationTest {
     public void testStartupAndShutdown() {
         elasticSearchNode = app.createAndManageChild(EntitySpec.create(ElasticSearchNode.class));
         app.start(ImmutableList.of(testLocation));
+        String url = elasticSearchNode.sensors().get(ElasticSearchNode.DATASTORE_URL);
         
         EntityTestUtils.assertAttributeEqualsEventually(elasticSearchNode, Startable.SERVICE_UP, true);
+        assertNotNull(url);
+        assertTrue(Networking.isReachable(HostAndPort.fromParts(URI.create(url).getHost(), URI.create(url).getPort())));
         
         elasticSearchNode.stop();
         

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/elasticsearch/ElasticSearchNodeIntegrationTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/elasticsearch/ElasticSearchNodeIntegrationTest.java
@@ -28,58 +28,47 @@ import java.net.URISyntaxException;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.Attributes;
-import org.apache.brooklyn.core.entity.Entities;
-import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
-import org.apache.brooklyn.core.test.entity.TestApplication;
+import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
 import org.apache.brooklyn.feed.http.HttpValueFunctions;
-import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
-import org.apache.brooklyn.util.http.HttpAsserts;
 import org.apache.brooklyn.util.http.HttpTool;
 import org.apache.brooklyn.util.http.HttpToolResponse;
 import org.apache.brooklyn.util.net.Networking;
 import org.apache.http.client.methods.HttpGet;
 import org.bouncycastle.util.Strings;
-import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
 
-public class ElasticSearchNodeIntegrationTest {
+public class ElasticSearchNodeIntegrationTest extends BrooklynAppLiveTestSupport {
     
-    protected TestApplication app;
     protected Location testLocation;
     protected ElasticSearchNode elasticSearchNode;
 
     @BeforeMethod(alwaysRun = true)
-    public void setup() throws Exception {
-        app = ApplicationBuilder.newManagedApp(TestApplication.class);
-        testLocation = new LocalhostMachineProvisioningLocation();
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        testLocation = app.newLocalhostProvisioningLocation();
     }
 
-    @AfterMethod(alwaysRun = true)
-    public void shutdown() {
-        Entities.destroyAll(app.getManagementContext());
-    }
-    
     @Test(groups = {"Integration"})
     public void testStartupAndShutdown() {
         elasticSearchNode = app.createAndManageChild(EntitySpec.create(ElasticSearchNode.class));
         app.start(ImmutableList.of(testLocation));
-        String url = elasticSearchNode.sensors().get(ElasticSearchNode.DATASTORE_URL);
         
-        EntityTestUtils.assertAttributeEqualsEventually(elasticSearchNode, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(elasticSearchNode, Startable.SERVICE_UP, true);
+        String url = elasticSearchNode.sensors().get(ElasticSearchNode.DATASTORE_URL);
         assertNotNull(url);
         assertTrue(Networking.isReachable(HostAndPort.fromParts(URI.create(url).getHost(), URI.create(url).getPort())));
         
         elasticSearchNode.stop();
         
-        EntityTestUtils.assertAttributeEqualsEventually(elasticSearchNode, Startable.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(elasticSearchNode, Startable.SERVICE_UP, false);
     }
     
     @Test(groups = {"Integration"})
@@ -87,9 +76,9 @@ public class ElasticSearchNodeIntegrationTest {
         elasticSearchNode = app.createAndManageChild(EntitySpec.create(ElasticSearchNode.class));
         app.start(ImmutableList.of(testLocation));
         
-        EntityTestUtils.assertAttributeEqualsEventually(elasticSearchNode, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(elasticSearchNode, Startable.SERVICE_UP, true);
         
-        EntityTestUtils.assertAttributeEquals(elasticSearchNode, ElasticSearchNode.DOCUMENT_COUNT, 0);
+        EntityAsserts.assertAttributeEquals(elasticSearchNode, ElasticSearchNode.DOCUMENT_COUNT, 0);
         
         String baseUri = "http://" + elasticSearchNode.getAttribute(Attributes.HOSTNAME) + ":" + elasticSearchNode.getAttribute(Attributes.HTTP_PORT);
         
@@ -115,6 +104,6 @@ public class ElasticSearchNodeIntegrationTest {
         assertEquals(getResponse.getResponseCode(), 200);
         assertEquals(HttpValueFunctions.jsonContents("foo", String.class).apply(getResponse), "bar");
         
-        EntityTestUtils.assertAttributeEqualsEventually(elasticSearchNode, ElasticSearchNode.DOCUMENT_COUNT, 1);
+        EntityAsserts.assertAttributeEqualsEventually(elasticSearchNode, ElasticSearchNode.DOCUMENT_COUNT, 1);
     }
 }


### PR DESCRIPTION
The first commit is the important one; the second is cosmetic, to get rid of deprecation warnings in the tests.