### PR TITLE
Populate catalog from bundle bom

### DIFF
--- a/examples/global-web-fabric/src/main/resources/catalog.bom
+++ b/examples/global-web-fabric/src/main/resources/catalog.bom
@@ -18,6 +18,7 @@
 brooklyn.catalog:
     version: 0.10.0-SNAPSHOT # BROOKLYN_VERSION
     items:
-    - id: com.example.HelloEntity
+    - id: org.apache.brooklyn.demo.GlobalWebFabricExample
       item:
-        type: com.example.HelloEntity
+        type: org.apache.brooklyn.demo.GlobalWebFabricExample
+        name: Global Web Fabric

--- a/examples/simple-nosql-cluster/src/main/resources/catalog.bom
+++ b/examples/simple-nosql-cluster/src/main/resources/catalog.bom
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+brooklyn.catalog:
+    version: 0.10.0-SNAPSHOT # BROOKLYN_VERSION
+    items:
+    - id: org.apache.brooklyn.demo.RiakClusterExample
+      item:
+        type: org.apache.brooklyn.demo.RiakClusterExample
+    - id: org.apache.brooklyn.demo.CumulusRDFApplication
+      item:
+        type: org.apache.brooklyn.demo.CumulusRDFApplication
+        name: Cumulus RDF Application
+        description: CumulusRDF Application on a Tomcat server using a multi-region Cassandra fabric
+    - id: org.apache.brooklyn.demo.ResilientMongoDbApp
+      item:
+        type: org.apache.brooklyn.demo.ResilientMongoDbApp
+        name: Resilient MongoDB
+    - id: org.apache.brooklyn.demo.StormSampleApp
+      item:
+        type: org.apache.brooklyn.demo.StormSampleApp
+        name: Storm Sample App
+    - id: org.apache.brooklyn.demo.WideAreaCassandraCluster
+      item:
+        type: org.apache.brooklyn.demo.WideAreaCassandraCluster
+        name: Wide Area Cassandra Cluster Application
+        description: Deploy a Cassandra cluster across multiple geographies.
+    - id: org.apache.brooklyn.demo.HighAvailabilityCassandraCluster
+      item:
+        type: org.apache.brooklyn.demo.HighAvailabilityCassandraCluster
+        name: HA Cassandra Cluster Application
+        description: Deploy a Cassandra cluster with a High Availability architecture.

--- a/examples/simple-web-cluster/src/main/resources/catalog.bom
+++ b/examples/simple-web-cluster/src/main/resources/catalog.bom
@@ -18,6 +18,11 @@
 brooklyn.catalog:
     version: 0.10.0-SNAPSHOT # BROOKLYN_VERSION
     items:
-    - id: com.example.HelloEntity
+    - id: org.apache.brooklyn.demo.NodeJsTodoApplication
       item:
-        type: com.example.HelloEntity
+        type: org.apache.brooklyn.demo.NodeJsTodoApplication
+        name: NodeJS Todo
+    - id: org.apache.brooklyn.demo.WebClusterDatabaseExampleApp
+      item:
+        type: org.apache.brooklyn.demo.WebClusterDatabaseExampleApp
+        name: Elastic Java Web + DB

--- a/sandbox/monitoring/src/main/resources/catalog.bom
+++ b/sandbox/monitoring/src/main/resources/catalog.bom
@@ -18,6 +18,6 @@
 brooklyn.catalog:
     version: 0.10.0-SNAPSHOT # BROOKLYN_VERSION
     items:
-    - id: com.example.HelloEntity
+    - id: org.apache.brooklyn.entity.monitoring.zabbix.ZabbixServer
       item:
-        type: com.example.HelloEntity
+        type: org.apache.brooklyn.entity.monitoring.zabbix.ZabbixServer

--- a/software/cm/ansible/src/main/resources/catalog.bom
+++ b/software/cm/ansible/src/main/resources/catalog.bom
@@ -18,6 +18,8 @@
 brooklyn.catalog:
     version: 0.10.0-SNAPSHOT # BROOKLYN_VERSION
     items:
-    - id: com.example.HelloEntity
+    - id: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
       item:
-        type: com.example.HelloEntity
+        type: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
+        name: AnsibleEntity
+        description: Software managed by Ansible CM

--- a/software/cm/salt/src/main/resources/catalog.bom
+++ b/software/cm/salt/src/main/resources/catalog.bom
@@ -18,6 +18,8 @@
 brooklyn.catalog:
     version: 0.10.0-SNAPSHOT # BROOKLYN_VERSION
     items:
-    - id: com.example.HelloEntity
+    - id: org.apache.brooklyn.entity.cm.salt.SaltEntity
       item:
-        type: com.example.HelloEntity
+        type: org.apache.brooklyn.entity.cm.salt.SaltEntity
+        name: SaltEntity
+        description: Software managed by Salt CM

--- a/software/database/src/main/resources/catalog.bom
+++ b/software/database/src/main/resources/catalog.bom
@@ -1,0 +1,46 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+brooklyn.catalog:
+    version: 0.10.0-SNAPSHOT # BROOKLYN_VERSION
+    items:
+    - id: org.apache.brooklyn.entity.database.crate.CrateNode
+      item:
+        type: org.apache.brooklyn.entity.database.crate.CrateNode
+    - id: org.apache.brooklyn.entity.database.mysql.MySqlNode
+      item:
+        type: org.apache.brooklyn.entity.database.mysql.MySqlNode
+        name: MySql Node
+        description: MySql is an open source relational database management system (RDBMS)
+    - id: org.apache.brooklyn.entity.database.mysql.MySqlCluster
+      item:
+        type: org.apache.brooklyn.entity.database.mysql.MySqlCluster
+        name: MySql Master-Slave cluster
+        description: Sets up a cluster of MySQL nodes using master-slave relation and binary logging
+    - id: org.apache.brooklyn.entity.database.postgresql.PostgreSqlNode
+      item:
+        type: org.apache.brooklyn.entity.database.postgresql.PostgreSqlNode
+        name: PostgreSQL Node
+        description: PostgreSQL is an object-relational database management system (ORDBMS)
+    - id: org.apache.brooklyn.entity.database.rubyrep.RubyRepNode
+      item:
+        type: org.apache.brooklyn.entity.database.rubyrep.RubyRepNode
+    - id: org.apache.brooklyn.entity.database.mariadb.MariaDbNode
+      item:
+        type: org.apache.brooklyn.entity.database.mariadb.MariaDbNode
+        name: MariaDB Node
+        description: MariaDB is an open source relational database management system (RDBMS)

--- a/software/messaging/src/main/resources/catalog.bom
+++ b/software/messaging/src/main/resources/catalog.bom
@@ -1,0 +1,78 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+brooklyn.catalog:
+    version: 0.10.0-SNAPSHOT # BROOKLYN_VERSION
+    items:
+    - id: org.apache.brooklyn.entity.messaging.activemq.ActiveMQBroker
+      item:
+        type: org.apache.brooklyn.entity.messaging.activemq.ActiveMQBroker
+        name: ActiveMQ Broker
+        description: ActiveMQ is an open source message broker which fully implements the Java Message Service 1.1 (JMS)
+    - id: org.apache.brooklyn.entity.messaging.qpid.QpidBroker
+      item:
+        type: org.apache.brooklyn.entity.messaging.qpid.QpidBroker
+        name: Qpid Broker
+        description: Apache Qpid is an open-source messaging system, implementing the Advanced Message Queuing Protocol (AMQP)
+    - id: org.apache.brooklyn.entity.messaging.storm.Storm
+      item:
+        type: org.apache.brooklyn.entity.messaging.storm.Storm
+        name: Storm Node
+        description: Apache Storm is a distributed realtime computation system. 
+    - id: org.apache.brooklyn.entity.messaging.kafka.KafkaCluster
+      item:
+        type: org.apache.brooklyn.entity.messaging.kafka.KafkaCluster
+        name: Kafka
+        description: Apache Kafka is a distributed publish-subscribe messaging system
+    - id: org.apache.brooklyn.entity.messaging.activemq.ActiveMQQueue
+      item:
+        type: org.apache.brooklyn.entity.messaging.activemq.ActiveMQQueue
+    - id: org.apache.brooklyn.entity.zookeeper.ZooKeeperEnsemble
+      item:
+        type: org.apache.brooklyn.entity.zookeeper.ZooKeeperEnsemble
+        name: ZooKeeper ensemble
+        description: A cluster of ZooKeeper servers. 
+    - id: org.apache.brooklyn.entity.messaging.kafka.KafkaZooKeeper
+      item:
+        type: org.apache.brooklyn.entity.messaging.kafka.KafkaZooKeeper
+    - id: org.apache.brooklyn.entity.messaging.activemq.ActiveMQTopic
+      item:
+        type: org.apache.brooklyn.entity.messaging.activemq.ActiveMQTopic
+    - id: org.apache.brooklyn.entity.messaging.qpid.QpidQueue
+      item:
+        type: org.apache.brooklyn.entity.messaging.qpid.QpidQueue
+    - id: org.apache.brooklyn.entity.zookeeper.ZooKeeperNode
+      item:
+        type: org.apache.brooklyn.entity.zookeeper.ZooKeeperNode
+        name: ZooKeeper Node
+        description: Apache ZooKeeper is a server which enables 
+    - id: org.apache.brooklyn.entity.messaging.rabbit.RabbitBroker
+      item:
+        type: org.apache.brooklyn.entity.messaging.rabbit.RabbitBroker
+        name: RabbitMQ Broker
+        description: RabbitMQ is an open source message broker software (i.e. message-oriented middleware) that implements the Advanced Message Queuing Protocol (AMQP) standard
+    - id: org.apache.brooklyn.entity.messaging.kafka.KafkaBroker
+      item:
+        type: org.apache.brooklyn.entity.messaging.kafka.KafkaBroker
+    - id: org.apache.brooklyn.entity.messaging.qpid.QpidTopic
+      item:
+        type: org.apache.brooklyn.entity.messaging.qpid.QpidTopic
+    - id: org.apache.brooklyn.entity.messaging.storm.StormDeployment
+      item:
+        type: org.apache.brooklyn.entity.messaging.storm.StormDeployment
+        name: Storm Deployment
+        description: A Storm cluster. Apache Storm is a distributed realtime computation system. 

--- a/software/monitoring/src/main/resources/catalog.bom
+++ b/software/monitoring/src/main/resources/catalog.bom
@@ -18,6 +18,8 @@
 brooklyn.catalog:
     version: 0.10.0-SNAPSHOT # BROOKLYN_VERSION
     items:
-    - id: com.example.HelloEntity
+    - id: org.apache.brooklyn.entity.monitoring.monit.MonitNode
       item:
-        type: com.example.HelloEntity
+        type: org.apache.brooklyn.entity.monitoring.monit.MonitNode
+        name: Monit Node
+        description: Monit is a free open source utility for managing and monitoring, processes, programs, files, directories and filesystems on a UNIX system

--- a/software/network/src/main/resources/catalog.bom
+++ b/software/network/src/main/resources/catalog.bom
@@ -18,6 +18,8 @@
 brooklyn.catalog:
     version: 0.10.0-SNAPSHOT # BROOKLYN_VERSION
     items:
-    - id: com.example.HelloEntity
+    - id: org.apache.brooklyn.entity.network.bind.BindDnsServer
       item:
-        type: com.example.HelloEntity
+        type: org.apache.brooklyn.entity.network.bind.BindDnsServer
+        name: BIND
+        description: BIND is an Internet Domain Name Server.

--- a/software/nosql/src/main/resources/catalog.bom
+++ b/software/nosql/src/main/resources/catalog.bom
@@ -1,0 +1,191 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+brooklyn.catalog:
+    version: 0.10.0-SNAPSHOT # BROOKLYN_VERSION
+    items:
+    - id: org.apache.brooklyn.entity.nosql.redis.RedisStore
+      item:
+        type: org.apache.brooklyn.entity.nosql.redis.RedisStore
+        name: Redis Server
+        description: Redis is an open-source, networked, in-memory, key-value data store with optional durability
+    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBRouterCluster
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBRouterCluster
+    - id: org.apache.brooklyn.entity.nosql.cassandra.CassandraDatacenter
+      item:
+        type: org.apache.brooklyn.entity.nosql.cassandra.CassandraDatacenter
+        name: Apache Cassandra Datacenter Cluster
+        description: Cassandra is a highly scalable, eventually 
+    - id: org.apache.brooklyn.entity.nosql.solr.SolrServer
+      item:
+        type: org.apache.brooklyn.entity.nosql.solr.SolrServer
+        name: Apache Solr Node
+        description: Solr is the popular, blazing fast open source enterprise search 
+    - id: org.apache.brooklyn.entity.nosql.couchdb.CouchDBNode
+      item:
+        type: org.apache.brooklyn.entity.nosql.couchdb.CouchDBNode
+        name: CouchDB Node
+    - id: org.apache.brooklyn.entity.nosql.redis.RedisShard
+      item:
+        type: org.apache.brooklyn.entity.nosql.redis.RedisShard
+    - id: org.apache.brooklyn.entity.nosql.redis.RedisCluster
+      item:
+        type: org.apache.brooklyn.entity.nosql.redis.RedisCluster
+        name: Redis Cluster
+        description: Redis is an open-source, networked, in-memory, key-value data store with optional durability
+    - id: org.apache.brooklyn.entity.nosql.hazelcast.HazelcastCluster
+      item:
+        type: org.apache.brooklyn.entity.nosql.hazelcast.HazelcastCluster
+        name: Hazelcast Cluster
+        description: Hazelcast is a clustering and highly scalable data distribution platform for Java.
+    - id: org.apache.brooklyn.entity.nosql.couchdb.CouchDBCluster
+      item:
+        type: org.apache.brooklyn.entity.nosql.couchdb.CouchDBCluster
+    - id: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseNode
+      item:
+        type: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseNode
+        name: CouchBase Node
+        description: Couchbase Server is an open source, distributed (shared-nothing architecture) 
+    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBShardedDeployment
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBShardedDeployment
+        name: MongoDB Sharded Deployment
+    - id: org.apache.brooklyn.entity.nosql.cassandra.CassandraNode
+      item:
+        type: org.apache.brooklyn.entity.nosql.cassandra.CassandraNode
+        name: Apache Cassandra Node
+        description: Cassandra is a highly scalable, eventually 
+    - id: org.apache.brooklyn.entity.nosql.riak.RiakNode
+      item:
+        type: org.apache.brooklyn.entity.nosql.riak.RiakNode
+        name: Riak Node
+        description: Riak is a distributed NoSQL key-value data store that offers 
+    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBConfigServerCluster
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBConfigServerCluster
+    - id: org.apache.brooklyn.entity.nosql.mongodb.MongoDBServer
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.MongoDBServer
+        name: MongoDB Server
+    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBRouter
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBRouter
+        name: MongoDB Router
+    - id: org.apache.brooklyn.entity.nosql.mongodb.MongoDBReplicaSet
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.MongoDBReplicaSet
+    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBShardCluster
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBShardCluster
+    - id: org.apache.brooklyn.entity.nosql.mongodb.MongoDBClient
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.MongoDBClient
+    - id: org.apache.brooklyn.entity.nosql.elasticsearch.ElasticSearchNode
+      item:
+        type: org.apache.brooklyn.entity.nosql.elasticsearch.ElasticSearchNode
+        name: Elastic Search Node
+        description: Elasticsearch is an open-source search server based on Lucene. 
+    - id: org.apache.brooklyn.entity.nosql.cassandra.CassandraFabric
+      item:
+        type: org.apache.brooklyn.entity.nosql.cassandra.CassandraFabric
+        name: Apache Cassandra Database Fabric
+        description: Cassandra is a highly scalable, eventually 
+    - id: org.apache.brooklyn.entity.nosql.elasticsearch.ElasticSearchCluster
+      item:
+        type: org.apache.brooklyn.entity.nosql.elasticsearch.ElasticSearchCluster
+        name: Elastic Search Cluster
+        description: Elasticsearch is an open-source search server based on Lucene. 
+    - id: org.apache.brooklyn.entity.nosql.cassandra.CassandraCluster
+      item:
+        type: org.apache.brooklyn.entity.nosql.cassandra.CassandraCluster
+    - id: org.apache.brooklyn.entity.nosql.redis.RedisSlave
+      item:
+        type: org.apache.brooklyn.entity.nosql.redis.RedisSlave
+    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBConfigServer
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBConfigServer
+    - id: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseCluster
+      item:
+        type: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseCluster
+        name: CouchBase Cluster
+        description: Couchbase is an open source, distributed (shared-nothing architecture) 
+    - id: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseSyncGateway
+      item:
+        type: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseSyncGateway
+    - id: org.apache.brooklyn.entity.nosql.hazelcast.HazelcastNode
+      item:
+        type: org.apache.brooklyn.entity.nosql.hazelcast.HazelcastNode
+        name: Hazelcast Node
+        description: Hazelcast is a clustering and highly scalable data distribution platform for Java.
+    - id: org.apache.brooklyn.entity.nosql.riak.RiakCluster
+      item:
+        type: org.apache.brooklyn.entity.nosql.riak.RiakCluster
+        name: Riak Cluster
+        description: Riak is a distributed NoSQL key-value data store that offers 
+    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.CoLocatedMongoDBRouter
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.CoLocatedMongoDBRouter
+
+
+    - id: bash-web-and-riak-template
+      itemType: template
+      name: "Template: Bash Web Server and Scaling Riak Cluster"
+      description: |
+        Sample YAML building on Template bash-web-server-template,
+        composing that blueprint with a Riak cluster and injecting the URL
+      item:
+        name: Bash Web Server and Riak Cluster (Brooklyn Example)
+
+        # this example *references* the previous one,
+        # combining it with a stock blueprint for a Riak cluster,
+        # and shows how a sensor from the latter can be injected
+
+        services:
+
+        # reference template bash-web-server-template, overriding message to point at riak
+        - type:           bash-web-server-template
+          brooklyn.config:
+            my.message:   $brooklyn:formatString("connected to Riak at %s",
+                              $brooklyn:entity("riak-cluster").attributeWhenReady("main.uri"))
+          # and clear the location defined there so it is taken from this template
+          locations:      []
+
+        # use the off-the-shelf Riak cluster
+        - type:           org.apache.brooklyn.entity.nosql.riak.RiakCluster
+          id:             riak-cluster
+          initialSize:    3
+          # and add a policy to scale based on ops per minute
+          brooklyn.policies:
+          - type: org.apache.brooklyn.policy.autoscaling.AutoScalerPolicy
+            brooklyn.config:
+              metric: riak.node.ops.1m.perNode
+              # more than 100 ops per second (6k/min) scales out, less than 50 scales back
+              # up to a max of 8 riak nodes here (can be changed in GUI / REST API afterwards)
+              metricLowerBound: 3000
+              metricUpperBound: 6000
+              minPoolSize: 3
+              maxPoolSize: 8
+              resizeUpStabilizationDelay: 30s
+              resizeDownStabilizationDelay: 5m
+
+        location:
+          jclouds:aws-ec2:
+            region:       eu-central-1
+            # edit these (or delete if credentials specified in brooklyn.properties)
+            identity:     <REPLACE>
+            credential:   <REPLACE>

--- a/software/osgi/src/main/resources/catalog.bom
+++ b/software/osgi/src/main/resources/catalog.bom
@@ -18,6 +18,8 @@
 brooklyn.catalog:
     version: 0.10.0-SNAPSHOT # BROOKLYN_VERSION
     items:
-    - id: com.example.HelloEntity
+    - id: org.apache.brooklyn.entity.osgi.karaf.KarafContainer
       item:
-        type: com.example.HelloEntity
+        type: org.apache.brooklyn.entity.osgi.karaf.KarafContainer
+        name: Karaf
+        description: Apache Karaf is a small OSGi based runtime which provides a lightweight container onto which various components and applications can be deployed.

--- a/software/webapp/src/main/resources/catalog.bom
+++ b/software/webapp/src/main/resources/catalog.bom
@@ -1,0 +1,234 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+brooklyn.catalog:
+    version: 0.10.0-SNAPSHOT # BROOKLYN_VERSION
+    items:
+    - id: org.apache.brooklyn.entity.webapp.nodejs.NodeJsWebAppService
+      item:
+        type: org.apache.brooklyn.entity.webapp.nodejs.NodeJsWebAppService
+        name: Node.JS Application
+    - id: org.apache.brooklyn.entity.webapp.jboss.JBoss7Server
+      item:
+        type: org.apache.brooklyn.entity.webapp.jboss.JBoss7Server
+        name: JBoss Application Server 7
+        description: AS7 - an open source Java application server from JBoss
+    - id: org.apache.brooklyn.entity.proxy.nginx.UrlMapping
+      item:
+        type: org.apache.brooklyn.entity.proxy.nginx.UrlMapping
+    - id: org.apache.brooklyn.entity.webapp.DynamicWebAppFabric
+      item:
+        type: org.apache.brooklyn.entity.webapp.DynamicWebAppFabric
+    - id: org.apache.brooklyn.entity.proxy.nginx.NginxController
+      item:
+        type: org.apache.brooklyn.entity.proxy.nginx.NginxController
+        name: Nginx Server
+        description: A single Nginx server. Provides HTTP and reverse proxy services
+    - id: org.apache.brooklyn.entity.webapp.jboss.JBoss6Server
+      item:
+        type: org.apache.brooklyn.entity.webapp.jboss.JBoss6Server
+        name: JBoss Application Server 6
+        description: AS6 -  an open source Java application server from JBoss
+    - id: org.apache.brooklyn.entity.webapp.tomcat.Tomcat8Server
+      item:
+        type: org.apache.brooklyn.entity.webapp.tomcat.Tomcat8Server
+        name: Tomcat Server
+    - id: org.apache.brooklyn.entity.proxy.LoadBalancerCluster
+      item:
+        type: org.apache.brooklyn.entity.proxy.LoadBalancerCluster
+    - id: org.apache.brooklyn.entity.webapp.jetty.Jetty6Server
+      item:
+        type: org.apache.brooklyn.entity.webapp.jetty.Jetty6Server
+        name: Jetty6 Server
+        description: Old version (v6 @ Mortbay) of the popular Jetty webapp container
+    - id: org.apache.brooklyn.entity.webapp.DynamicWebAppCluster
+      item:
+        type: org.apache.brooklyn.entity.webapp.DynamicWebAppCluster
+        name: Dynamic Web-app Cluster
+        description: A cluster of web-apps, which can be dynamically re-sized; this does not include a load-balancer
+    - id: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
+      item:
+        type: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
+        name: Tomcat Server
+    - id: org.apache.brooklyn.entity.dns.geoscaling.GeoscalingDnsService
+      item:
+        type: org.apache.brooklyn.entity.dns.geoscaling.GeoscalingDnsService
+    - id: org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster
+      item:
+        type: org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster
+        name: Controlled Dynamic Web-app Cluster
+        description: A cluster of load-balanced web-apps, which can be dynamically re-sized
+
+    - id: load-balancer
+      description: |
+        Create a load balancer which will point at members in the group entity
+        referred to by the config key "serverPool".
+        The sensor advertising the port can be configured with the "member.sensor.portNumber" config key,
+        defaulting to `http.port`; all member entities which have published "service.up" will then be picked up.
+      item:
+        type: org.apache.brooklyn.entity.proxy.nginx.NginxController
+        name: Load Balancer (nginx)
+
+    - id: resilient-bash-web-cluster-template
+      itemType: template
+      name: "Template: Resilient Load-Balanced Bash Web Cluster with Sensors"
+      description: |
+        Sample YAML to provision a cluster of the bash/python web server nodes,
+        with sensors configured, and a load balancer pointing at them,
+        and resilience policies for node replacement and scaling
+      item:
+        name: Resilient Load-Balanced Bash Web Cluster (Brooklyn Example)
+
+        # this final example shows some of the advanced functionality:
+        # defining custom sensors, and a cluster with a "spec",
+        # policies for resilience and scaling based on that sensor,
+        # and wiring a load balancer in front of the cluster
+
+        # combining this with the riak cluster in the previous example
+        # is left as a suggested exercise for the user
+
+        services:
+
+        # define a cluster of the web nodes
+        - type:           cluster
+          name:           Cluster of Bash Web Nodes
+          id:             my-web-cluster
+          brooklyn.config:
+            initialSize:  1
+            memberSpec:
+              $brooklyn:entitySpec:
+                # template bash-web-server-template is used as the spec for items in this cluster
+                # with a new message overwriting the previous,
+                # and a lot of sensors defined
+                type:           bash-web-server-template
+                name:           My Bash Web Server VM with Sensors
+                # and clear the location defined there so it is taken from this template
+                locations:      []
+
+                brooklyn.config:
+                  my.message:   "part of the cluster"
+
+                brooklyn.initializers:
+                # make a simple request-count sensor, by counting the number of 200 responses in output.txt
+                - type: org.apache.brooklyn.core.sensor.ssh.SshCommandSensor
+                  brooklyn.config:
+                    name: reqs.count
+                    targetType: int
+                    period: 5s
+                    command: "cat output.txt | grep HTTP | grep 200 | wc | awk '{print $1}'"
+                # and publish the port as a sensor so the load-balancer can pick it up
+                - type:           org.apache.brooklyn.core.sensor.StaticSensor
+                  brooklyn.config:
+                    name:         app.port
+                    targetType:   int
+                    static.value: $brooklyn:config("my.app.port")
+
+                brooklyn.enrichers:
+                # derive reqs.per_sec from reqs.count
+                - type: org.apache.brooklyn.enricher.stock.YamlTimeWeightedDeltaEnricher
+                  brooklyn.config:
+                    enricher.sourceSensor: reqs.count
+                    enricher.targetSensor: reqs.per_sec
+                    enricher.delta.period: 1s
+                # and take an average over 30s for reqs.per_sec into reqs.per_sec.windowed_30s
+                - type: org.apache.brooklyn.enricher.stock.YamlRollingTimeWindowMeanEnricher
+                  brooklyn.config:
+                    enricher.sourceSensor: reqs.per_sec
+                    enricher.targetSensor: reqs.per_sec.windowed_30s
+                    enricher.window.duration: 30s
+
+                brooklyn.policies:
+                # restart if a failure is detected (with a max of one restart in 2m, sensor will propagate otherwise)
+                - type: org.apache.brooklyn.policy.ha.ServiceRestarter
+                  brooklyn.config:
+                    failOnRecurringFailuresInThisDuration: 2m
+
+          # back at the cluster, create a total per-sec and some per-node average
+          brooklyn.enrichers:
+          - type: org.apache.brooklyn.enricher.stock.Aggregator
+            brooklyn.config:
+              enricher.sourceSensor: reqs.per_sec
+              enricher.targetSensor: reqs.per_sec
+              transformation: sum
+          - type: org.apache.brooklyn.enricher.stock.Aggregator
+            brooklyn.config:
+              enricher.sourceSensor: reqs.per_sec
+              enricher.targetSensor: reqs.per_sec.per_node
+              transformation: average
+          - type: org.apache.brooklyn.enricher.stock.Aggregator
+            brooklyn.config:
+              enricher.sourceSensor: reqs.per_sec.windowed_30s
+              enricher.targetSensor: reqs.per_sec.windowed_30s.per_node
+              transformation: average
+
+          brooklyn.policies:
+          # resilience: if a per-node restart policy fails,
+          # just throw that node away and create a new one
+          - type: org.apache.brooklyn.policy.ha.ServiceReplacer
+
+          # and scale based on reqs/sec
+          - type: org.apache.brooklyn.policy.autoscaling.AutoScalerPolicy
+            brooklyn.config:
+              # scale based on reqs/sec (though in a real-world situation,
+              # reqs.per_sec.windowed_30s.per_node might be a better choice)
+              metric: reqs.per_sec.per_node
+
+              # really low numbers, so you can trigger a scale-out just by hitting reload a lot
+              metricUpperBound: 3
+              metricLowerBound: 1
+
+              # sustain 3 reqs/sec for 2s and it will scale out
+              resizeUpStabilizationDelay: 2s
+              # only scale down when sustained for 1m
+              resizeDownStabilizationDelay: 1m
+
+              maxPoolSize: 10
+
+        # and add a load-balancer pointing at the cluster
+        - type:           load-balancer
+          id:             load-bal
+          brooklyn.config:
+            # point this load balancer at the cluster, specifying port to forward to
+            loadbalancer.serverpool:  $brooklyn:entity("my-web-cluster")
+            member.sensor.portNumber: app.port
+            # disable sticky sessions to allow easy validation of balancing via browser refresh
+            nginx.sticky: false
+
+        brooklyn.enrichers:
+        # publish a few useful info sensors and KPI's to the root of the app
+        - type: org.apache.brooklyn.enricher.stock.Propagator
+          brooklyn.config:
+            uniqueTag:    propagate-load-balancer-url
+            producer:     $brooklyn:entity("load-bal")
+            propagating:
+            - main.uri
+        - type: org.apache.brooklyn.enricher.stock.Propagator
+          brooklyn.config:
+            uniqueTag:    propagate-reqs-per-sec
+            producer:     $brooklyn:entity("my-web-cluster")
+            propagating:
+            - reqs.per_sec
+            - reqs.per_sec.windowed_30s.per_node
+
+        location:
+          jclouds:aws-ec2:
+            # edit these (or delete if credentials specified in brooklyn.properties)
+            identity:     <REPLACE>
+            credential:   <REPLACE>
+
+            region:       eu-central-1
+            minRam:       2gb


### PR DESCRIPTION
The PR adds updates to the existing jars to add a catalog.bom file that includes the details of the various entities in each.  

See https://github.com/apache/brooklyn-server/pull/80 for details; this PR depends on that one and should be merged after it.
