### PR TITLE
Fix: ElasticSearch used Java version

### DIFF
--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/elasticsearch/ElasticSearchNode.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/elasticsearch/ElasticSearchNode.java
@@ -29,6 +29,7 @@ import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey.StringAt
 import org.apache.brooklyn.core.sensor.PortAttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.entity.database.DatastoreMixins;
+import org.apache.brooklyn.entity.java.UsesJava;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.entity.webapp.WebAppServiceConstants;
 import org.apache.brooklyn.util.core.ResourcePredicates;
@@ -41,7 +42,7 @@ import org.apache.brooklyn.util.core.flags.SetFromFlag;
         + "It provides a distributed, multitenant-capable full-text search engine with a RESTful web interface and "
         + "schema-free JSON documents.")
 @ImplementedBy(ElasticSearchNodeImpl.class)
-public interface ElasticSearchNode extends SoftwareProcess, DatastoreMixins.HasDatastoreUrl {
+public interface ElasticSearchNode extends SoftwareProcess, UsesJava, DatastoreMixins.HasDatastoreUrl {
 
     @SetFromFlag("version")
     ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "1.2.1");

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/elasticsearch/ElasticSearchNodeDriver.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/elasticsearch/ElasticSearchNodeDriver.java
@@ -18,8 +18,8 @@
  */
 package org.apache.brooklyn.entity.nosql.elasticsearch;
 
-import org.apache.brooklyn.entity.software.base.SoftwareProcessDriver;
+import org.apache.brooklyn.entity.java.JavaSoftwareProcessDriver;
 
-public interface ElasticSearchNodeDriver extends SoftwareProcessDriver {
+public interface ElasticSearchNodeDriver extends JavaSoftwareProcessDriver {
 
 }

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/elasticsearch/ElasticSearchNodeSshDriver.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/elasticsearch/ElasticSearchNodeSshDriver.java
@@ -24,8 +24,8 @@ import java.util.List;
 
 import com.google.common.collect.ImmutableList;
 
-import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.config.ConfigKey;
+import org.apache.brooklyn.entity.java.JavaSoftwareProcessSshDriver;
 import org.apache.brooklyn.entity.software.base.AbstractSoftwareProcessSshDriver;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -33,9 +33,9 @@ import org.apache.brooklyn.util.net.Urls;
 import org.apache.brooklyn.util.os.Os;
 import org.apache.brooklyn.util.ssh.BashCommands;
 
-public class ElasticSearchNodeSshDriver extends AbstractSoftwareProcessSshDriver implements ElasticSearchNodeDriver {
+public class ElasticSearchNodeSshDriver extends JavaSoftwareProcessSshDriver implements ElasticSearchNodeDriver {
 
-    public ElasticSearchNodeSshDriver(EntityLocal entity, SshMachineLocation machine) {
+    public ElasticSearchNodeSshDriver(ElasticSearchNodeImpl entity, SshMachineLocation machine) {
         super(entity, machine);
     }
 
@@ -45,7 +45,6 @@ public class ElasticSearchNodeSshDriver extends AbstractSoftwareProcessSshDriver
         String saveAs = resolver.getFilename();
         
         List<String> commands = ImmutableList.<String>builder()
-            .add(BashCommands.installJavaLatestOrWarn())
             .addAll(BashCommands.commandsToDownloadUrlsAs(urls, saveAs))
             .add(String.format("tar zxvf %s", saveAs))
             .build();
@@ -127,4 +126,9 @@ public class ElasticSearchNodeSshDriver extends AbstractSoftwareProcessSshDriver
         newScript(MutableMap.of("usePidFile", true), KILLING).execute();
     }
 
+    @Override
+    protected String getLogFileLocation() {
+        String  logFileLocation = entity.config().get(ElasticSearchNode.LOG_DIR);
+        return (logFileLocation != null) ? logFileLocation : Os.mergePaths(getRunDir(), "logs");
+    }
 }


### PR DESCRIPTION
Making ElasticSearch to use JavaSoftwareProcessDriver so the correct
java version is installed. ElasticSearch used to install java via
BashCommands#installJavaLatestOrWarn(). It prevents setting the
installed java version as default when:
- the VM image comes with preinstalled jdk 6 or jdk7
- CentOS version of JDK8 doesn't update the default automatically