### PR TITLE
Updating deprecate EntityTestUtils to EntityAsserts

### DIFF
--- a/examples/simple-web-cluster/src/test/java/org/apache/brooklyn/demo/RebindWebClusterDatabaseExampleAppIntegrationTest.java
+++ b/examples/simple-web-cluster/src/test/java/org/apache/brooklyn/demo/RebindWebClusterDatabaseExampleAppIntegrationTest.java
@@ -23,6 +23,7 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.sensor.Enricher;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.StartableApplication;
 import org.apache.brooklyn.core.mgmt.rebind.RebindOptions;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixture;
@@ -32,7 +33,6 @@ import org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster;
 import org.apache.brooklyn.entity.webapp.DynamicWebAppCluster;
 import org.apache.brooklyn.entity.webapp.tomcat.Tomcat8Server;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.test.HttpTestUtils;
 import org.apache.brooklyn.test.WebAppMonitor;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -162,7 +162,7 @@ public class RebindWebClusterDatabaseExampleAppIntegrationTest extends RebindTes
         AutoScalerPolicy autoScalerPolicy = (AutoScalerPolicy) Iterables.find(webCluster.policies(), Predicates.instanceOf(AutoScalerPolicy.class));
         
         autoScalerPolicy.config().set(AutoScalerPolicy.MIN_POOL_SIZE, 3);
-        EntityTestUtils.assertGroupSizeEqualsEventually(web, 3);
+        EntityAsserts.assertGroupSizeEqualsEventually(web, 3);
         final Collection<Entity> webMembersAfterGrow = web.getMembers();
         
         for (final Entity appserver : webMembersAfterGrow) {
@@ -182,15 +182,15 @@ public class RebindWebClusterDatabaseExampleAppIntegrationTest extends RebindTes
 
         // Check we see evidence of the enrichers having an effect.
         // Relying on WebAppMonitor to stimulate activity.
-        EntityTestUtils.assertAttributeEqualsEventually(app, WebClusterDatabaseExampleApp.APPSERVERS_COUNT, 3);
-        EntityTestUtils.assertAttributeChangesEventually(web, DynamicWebAppCluster.REQUESTS_PER_SECOND_IN_WINDOW);
-        EntityTestUtils.assertAttributeChangesEventually(app, DynamicWebAppCluster.REQUESTS_PER_SECOND_IN_WINDOW);
-        EntityTestUtils.assertAttributeChangesEventually(web, HttpLatencyDetector.REQUEST_LATENCY_IN_SECONDS_MOST_RECENT);
-        EntityTestUtils.assertAttributeChangesEventually(web, HttpLatencyDetector.REQUEST_LATENCY_IN_SECONDS_IN_WINDOW);
+        EntityAsserts.assertAttributeEqualsEventually(app, WebClusterDatabaseExampleApp.APPSERVERS_COUNT, 3);
+        EntityAsserts.assertAttributeChangesEventually(web, DynamicWebAppCluster.REQUESTS_PER_SECOND_IN_WINDOW);
+        EntityAsserts.assertAttributeChangesEventually(app, DynamicWebAppCluster.REQUESTS_PER_SECOND_IN_WINDOW);
+        EntityAsserts.assertAttributeChangesEventually(web, HttpLatencyDetector.REQUEST_LATENCY_IN_SECONDS_MOST_RECENT);
+        EntityAsserts.assertAttributeChangesEventually(web, HttpLatencyDetector.REQUEST_LATENCY_IN_SECONDS_IN_WINDOW);
 
         // Restore the web-cluster to its original size of 2
         autoScalerPolicy.config().set(AutoScalerPolicy.MIN_POOL_SIZE, 2);
-        EntityTestUtils.assertGroupSizeEqualsEventually(web, 2);
+        EntityAsserts.assertGroupSizeEqualsEventually(web, 2);
         
         final Entity removedAppserver = Iterables.getOnlyElement(Sets.difference(ImmutableSet.copyOf(webMembersAfterGrow), ImmutableSet.copyOf(web.getMembers())));
         Asserts.succeedsEventually(new Runnable() {

--- a/qa/src/test/java/org/apache/brooklyn/qa/brooklynnode/SoftlayerObtainPrivateLiveTest.java
+++ b/qa/src/test/java/org/apache/brooklyn/qa/brooklynnode/SoftlayerObtainPrivateLiveTest.java
@@ -28,6 +28,7 @@ import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.core.objs.BrooklynObjectInternal.ConfigurationSupportInternal;
@@ -39,7 +40,6 @@ import org.apache.brooklyn.entity.brooklynnode.BrooklynNode.DeployBlueprintEffec
 import org.apache.brooklyn.entity.machine.MachineEntity;
 import org.apache.brooklyn.launcher.BrooklynLauncher;
 import org.apache.brooklyn.location.jclouds.JcloudsLocationConfig;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.BrooklynMavenArtifacts;
@@ -149,16 +149,16 @@ public class SoftlayerObtainPrivateLiveTest {
             BrooklynEntityMirror publicApp = deployTestApp(node, true);
             BrooklynEntityMirror privateApp = deployTestApp(node, false);
 
-            EntityTestUtils.assertAttributeEventually(TIMEOUT, publicApp, ServiceStateLogic.SERVICE_STATE_ACTUAL,
+            EntityAsserts.assertAttributeEventually(TIMEOUT, publicApp, ServiceStateLogic.SERVICE_STATE_ACTUAL,
                     Predicates.in(ImmutableList.of(Lifecycle.RUNNING, Lifecycle.ON_FIRE)));
-            EntityTestUtils.assertAttributeEventually(TIMEOUT, privateApp, ServiceStateLogic.SERVICE_STATE_ACTUAL,
+            EntityAsserts.assertAttributeEventually(TIMEOUT, privateApp, ServiceStateLogic.SERVICE_STATE_ACTUAL,
                     Predicates.in(ImmutableList.of(Lifecycle.RUNNING, Lifecycle.ON_FIRE)));
 
-            EntityTestUtils.assertAttributeEquals(publicApp, ServiceStateLogic.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
-            EntityTestUtils.assertAttributeEquals(privateApp, ServiceStateLogic.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+            EntityAsserts.assertAttributeEquals(publicApp, ServiceStateLogic.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+            EntityAsserts.assertAttributeEquals(privateApp, ServiceStateLogic.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
 
-            EntityTestUtils.assertAttributeEqualsEventually(publicApp, Attributes.SERVICE_UP, Boolean.TRUE);
-            EntityTestUtils.assertAttributeEqualsEventually(privateApp, Attributes.SERVICE_UP, Boolean.TRUE);
+            EntityAsserts.assertAttributeEqualsEventually(publicApp, Attributes.SERVICE_UP, Boolean.TRUE);
+            EntityAsserts.assertAttributeEqualsEventually(privateApp, Attributes.SERVICE_UP, Boolean.TRUE);
         } finally {
             node.invoke(BrooklynNode.STOP_NODE_AND_KILL_APPS, ImmutableMap.<String, String>of()).getUnchecked();
         }

--- a/qa/src/test/java/org/apache/brooklyn/qa/camp/EnrichersSlightlySimplerYamlTest.java
+++ b/qa/src/test/java/org/apache/brooklyn/qa/camp/EnrichersSlightlySimplerYamlTest.java
@@ -27,11 +27,11 @@ import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.camp.brooklyn.AbstractYamlTest;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.entity.group.DynamicCluster;
 import org.apache.brooklyn.entity.webapp.JavaWebAppSoftwareProcess;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.CollectionFunctionals;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.math.MathPredicates;
@@ -65,8 +65,8 @@ public class EnrichersSlightlySimplerYamlTest extends AbstractYamlTest {
         
         Entity e1 = li.next();
         ((EntityInternal)e1).sensors().set(Sensors.newStringSensor("ip"), "127.0.0.1");
-        EntityTestUtils.assertAttributeEqualsEventually(e1, Sensors.newStringSensor("url"), "http://127.0.0.1/");
-        EntityTestUtils.assertAttributeEqualsEventually(e1, Attributes.MAIN_URI, URI.create("http://127.0.0.1/"));
+        EntityAsserts.assertAttributeEqualsEventually(e1, Sensors.newStringSensor("url"), "http://127.0.0.1/");
+        EntityAsserts.assertAttributeEqualsEventually(e1, Attributes.MAIN_URI, URI.create("http://127.0.0.1/"));
 
         int i=2;
         while (li.hasNext()) {
@@ -75,17 +75,17 @@ public class EnrichersSlightlySimplerYamlTest extends AbstractYamlTest {
             i++;
         }
         
-        EntityTestUtils.assertAttributeEventually(cluster, Sensors.newSensor(Iterable.class, "urls.list"),
+        EntityAsserts.assertAttributeEventually(cluster, Sensors.newSensor(Iterable.class, "urls.list"),
             (Predicate)CollectionFunctionals.sizeEquals(3));
         
-        EntityTestUtils.assertAttributeEventually(cluster, Sensors.newSensor(String.class, "urls.list.comma_separated.max_2"),
+        EntityAsserts.assertAttributeEventually(cluster, Sensors.newSensor(String.class, "urls.list.comma_separated.max_2"),
             StringPredicates.matchesRegex("\"http:\\/\\/127[^\"]*\\/\",\"http:\\/\\/127[^\"]*\\/\""));
 
-        EntityTestUtils.assertAttributeEventually(cluster, Attributes.MAIN_URI, Predicates.notNull());
+        EntityAsserts.assertAttributeEventually(cluster, Attributes.MAIN_URI, Predicates.notNull());
         URI main = cluster.getAttribute(Attributes.MAIN_URI);
         Assert.assertTrue(main.toString().matches("http:\\/\\/127.0.0..\\/"), "Wrong URI: "+main);
         
-        EntityTestUtils.assertAttributeEventually(app, Attributes.MAIN_URI, Predicates.notNull());
+        EntityAsserts.assertAttributeEventually(app, Attributes.MAIN_URI, Predicates.notNull());
         main = app.getAttribute(Attributes.MAIN_URI);
         Assert.assertTrue(main.toString().matches("http:\\/\\/127.0.0..\\/"), "Wrong URI: "+main);
         
@@ -108,21 +108,21 @@ public class EnrichersSlightlySimplerYamlTest extends AbstractYamlTest {
         
         srv0.sensors().set(Sensors.newDoubleSensor("my.load"), 20.0);
         
-        EntityTestUtils.assertAttributeEventually(dwac, Sensors.newSensor(Double.class, "my.load.averaged"),
+        EntityAsserts.assertAttributeEventually(dwac, Sensors.newSensor(Double.class, "my.load.averaged"),
             MathPredicates.equalsApproximately(20));
-        EntityTestUtils.assertAttributeEventually(cdwac, Sensors.newSensor(Double.class, "my.load.averaged"),
+        EntityAsserts.assertAttributeEventually(cdwac, Sensors.newSensor(Double.class, "my.load.averaged"),
             MathPredicates.equalsApproximately(20));
 
         srv0.sensors().set(Sensors.newDoubleSensor("my.load"), null);
-        EntityTestUtils.assertAttributeEventually(cdwac, Sensors.newSensor(Double.class, "my.load.averaged"),
+        EntityAsserts.assertAttributeEventually(cdwac, Sensors.newSensor(Double.class, "my.load.averaged"),
             Predicates.isNull());
 
         ((EntityInternal) appservers.get(1)).sensors().set(Sensors.newDoubleSensor("my.load"), 10.0);
         ((EntityInternal) appservers.get(2)).sensors().set(Sensors.newDoubleSensor("my.load"), 20.0);
-        EntityTestUtils.assertAttributeEventually(cdwac, Sensors.newSensor(Double.class, "my.load.averaged"),
+        EntityAsserts.assertAttributeEventually(cdwac, Sensors.newSensor(Double.class, "my.load.averaged"),
             MathPredicates.equalsApproximately(15));
         srv0.sensors().set(Sensors.newDoubleSensor("my.load"), 0.0);
-        EntityTestUtils.assertAttributeEventually(cdwac, Sensors.newSensor(Double.class, "my.load.averaged"),
+        EntityAsserts.assertAttributeEventually(cdwac, Sensors.newSensor(Double.class, "my.load.averaged"),
             MathPredicates.equalsApproximately(10));
     }
     

--- a/qa/src/test/java/org/apache/brooklyn/qa/camp/JavaWebAppsIntegrationTest.java
+++ b/qa/src/test/java/org/apache/brooklyn/qa/camp/JavaWebAppsIntegrationTest.java
@@ -40,13 +40,13 @@ import org.apache.brooklyn.camp.spi.PlatformRootSummary;
 import org.apache.brooklyn.camp.spi.collection.ResolvableLink;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.mgmt.BrooklynTaskTags;
 import org.apache.brooklyn.entity.webapp.DynamicWebAppCluster;
 import org.apache.brooklyn.entity.webapp.JavaWebAppService;
 import org.apache.brooklyn.entity.webapp.WebAppService;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.exceptions.Exceptions;
@@ -169,7 +169,7 @@ public class JavaWebAppsIntegrationTest {
             log.info("App started:");
             Entities.dumpInfo(app);
 
-            EntityTestUtils.assertAttributeEqualsEventually(app, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+            EntityAsserts.assertAttributeEqualsEventually(app, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
             Assert.assertEquals(app.getAttribute(Attributes.SERVICE_UP), Boolean.TRUE);
             
             final String url = Asserts.succeedsEventually(MutableMap.of("timeout", Duration.TEN_SECONDS), new Callable<String>() {
@@ -242,7 +242,7 @@ public class JavaWebAppsIntegrationTest {
             Assert.assertEquals(policy.getConfig(AutoScalerPolicy.METRIC_UPPER_BOUND), (Integer)100);
             Assert.assertTrue(policy.isRunning());
 
-            EntityTestUtils.assertAttributeEqualsEventually(app, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+            EntityAsserts.assertAttributeEqualsEventually(app, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
             Assert.assertEquals(app.getAttribute(Attributes.SERVICE_UP), Boolean.TRUE);
             
             final String url = Asserts.succeedsEventually(MutableMap.of("timeout", Duration.TEN_SECONDS), new Callable<String>() {

--- a/sandbox/nosql/src/test/java/org/apache/brooklyn/entity/nosql/infinispan/Infinispan5ServerIntegrationTest.java
+++ b/sandbox/nosql/src/test/java/org/apache/brooklyn/entity/nosql/infinispan/Infinispan5ServerIntegrationTest.java
@@ -30,7 +30,6 @@ import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.location.PortRanges;
 import org.apache.brooklyn.core.test.entity.TestApplicationImpl;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.net.Networking;
 import org.apache.brooklyn.util.repeat.Repeater;
 import org.apache.brooklyn.util.time.Duration;
@@ -96,7 +95,7 @@ class Infinispan5ServerIntegrationTest {
             final Infinispan5Server infini = new Infinispan5Server(ImmutableMap.of("parent", app));
             infini.config().set(Infinispan5Server.PORT.getConfigKey(), PortRanges.fromInteger(DEFAULT_PORT));
             infini.start(ImmutableList.of(new LocalhostMachineProvisioningLocation(ImmutableMap.of("name","london"))));
-            EntityTestUtils.assertAttributeEqualsEventually(infini, Infinispan5Server.SERVICE_UP, Boolean.TRUE);
+            EntityAsserts.assertAttributeEqualsEventually(infini, Infinispan5Server.SERVICE_UP, Boolean.TRUE);
         } finally {
             Entities.destroy(app);
         }

--- a/software/database/src/test/java/org/apache/brooklyn/entity/database/crate/CrateNodeIntegrationTest.java
+++ b/software/database/src/test/java/org/apache/brooklyn/entity/database/crate/CrateNodeIntegrationTest.java
@@ -22,10 +22,10 @@ import static org.testng.Assert.assertFalse;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -55,8 +55,8 @@ public class CrateNodeIntegrationTest {
         CrateNode entity = app.createAndManageChild(EntitySpec.create(CrateNode.class));
         app.start(ImmutableList.of(localhostProvisioningLocation));
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, true);
-        EntityTestUtils.assertAttributeEventuallyNonNull(entity, CrateNode.SERVER_NAME);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEventuallyNonNull(entity, CrateNode.SERVER_NAME);
 
         entity.stop();
         assertFalse(entity.getAttribute(Startable.SERVICE_UP));

--- a/software/database/src/test/java/org/apache/brooklyn/entity/database/postgresql/PostgreSqlRebindIntegrationTest.java
+++ b/software/database/src/test/java/org/apache/brooklyn/entity/database/postgresql/PostgreSqlRebindIntegrationTest.java
@@ -19,8 +19,8 @@
 package org.apache.brooklyn.entity.database.postgresql;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
@@ -50,8 +50,8 @@ public class PostgreSqlRebindIntegrationTest extends RebindTestFixtureWithApp {
         final PostgreSqlNode newEntity = (PostgreSqlNode) Iterables.find(newApp.getChildren(), Predicates.instanceOf(PostgreSqlNode.class));
 
         // confirm effectors still work on entity
-        EntityTestUtils.assertAttributeEqualsEventually(newEntity, PostgreSqlNode.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(newEntity, PostgreSqlNode.SERVICE_UP, true);
         newEntity.stop();
-        EntityTestUtils.assertAttributeEqualsEventually(newEntity, PostgreSqlNode.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(newEntity, PostgreSqlNode.SERVICE_UP, false);
     }
 }

--- a/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/activemq/ActiveMQEc2LiveTest.java
+++ b/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/activemq/ActiveMQEc2LiveTest.java
@@ -30,9 +30,9 @@ import javax.jms.TextMessage;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -52,8 +52,8 @@ public class ActiveMQEc2LiveTest extends AbstractEc2LiveTest {
         ActiveMQBroker activeMQ = app.createAndManageChild(EntitySpec.create(ActiveMQBroker.class).configure("queue", queueName));
         
         app.start(ImmutableList.of(loc));
-        
-        EntityTestUtils.assertAttributeEqualsEventually(activeMQ, Startable.SERVICE_UP, true);
+
+        EntityAsserts.assertAttributeEqualsEventually(activeMQ, Startable.SERVICE_UP, true);
 
         // Check queue created
         assertEquals(ImmutableList.copyOf(activeMQ.getQueueNames()), ImmutableList.of(queueName));
@@ -67,11 +67,11 @@ public class ActiveMQEc2LiveTest extends AbstractEc2LiveTest {
         // Connect to broker using JMS and send messages
         Connection connection = getActiveMQConnection(activeMQ);
         clearQueue(connection, queueName);
-        EntityTestUtils.assertAttributeEqualsEventually(queue, ActiveMQQueue.QUEUE_DEPTH_MESSAGES, 0);
+        EntityAsserts.assertAttributeEqualsEventually(queue, ActiveMQQueue.QUEUE_DEPTH_MESSAGES, 0);
         sendMessages(connection, number, queueName, content);
 
         // Check messages arrived
-        EntityTestUtils.assertAttributeEqualsEventually(queue, ActiveMQQueue.QUEUE_DEPTH_MESSAGES, number);
+        EntityAsserts.assertAttributeEqualsEventually(queue, ActiveMQQueue.QUEUE_DEPTH_MESSAGES, number);
 
         connection.close();
     }

--- a/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/activemq/ActiveMQGoogleComputeLiveTest.java
+++ b/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/activemq/ActiveMQGoogleComputeLiveTest.java
@@ -23,9 +23,9 @@ import com.google.common.collect.ImmutableList;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.entity.AbstractGoogleComputeLiveTest;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.Test;
 
 import javax.jms.Connection;
@@ -52,8 +52,8 @@ public class ActiveMQGoogleComputeLiveTest extends AbstractGoogleComputeLiveTest
         ActiveMQBroker activeMQ = app.createAndManageChild(EntitySpec.create(ActiveMQBroker.class).configure("queue", queueName));
         
         app.start(ImmutableList.of(loc));
-        
-        EntityTestUtils.assertAttributeEqualsEventually(activeMQ, Startable.SERVICE_UP, true);
+
+        EntityAsserts.assertAttributeEqualsEventually(activeMQ, Startable.SERVICE_UP, true);
 
         // Check queue created
         assertEquals(ImmutableList.copyOf(activeMQ.getQueueNames()), ImmutableList.of(queueName));
@@ -67,11 +67,11 @@ public class ActiveMQGoogleComputeLiveTest extends AbstractGoogleComputeLiveTest
         // Connect to broker using JMS and send messages
         Connection connection = getActiveMQConnection(activeMQ);
         clearQueue(connection, queueName);
-        EntityTestUtils.assertAttributeEqualsEventually(queue, ActiveMQQueue.QUEUE_DEPTH_MESSAGES, 0);
+        EntityAsserts.assertAttributeEqualsEventually(queue, ActiveMQQueue.QUEUE_DEPTH_MESSAGES, 0);
         sendMessages(connection, number, queueName, content);
 
         // Check messages arrived
-        EntityTestUtils.assertAttributeEqualsEventually(queue, ActiveMQQueue.QUEUE_DEPTH_MESSAGES, number);
+        EntityAsserts.assertAttributeEqualsEventually(queue, ActiveMQQueue.QUEUE_DEPTH_MESSAGES, number);
 
         connection.close();
     }

--- a/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/activemq/ActiveMQIntegrationTest.java
+++ b/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/activemq/ActiveMQIntegrationTest.java
@@ -34,12 +34,12 @@ import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.java.UsesJmx;
 import org.apache.brooklyn.entity.java.UsesJmx.JmxAgentModes;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -79,7 +79,7 @@ public class ActiveMQIntegrationTest {
         activeMQ = app.createAndManageChild(EntitySpec.create(ActiveMQBroker.class));
 
         activeMQ.start(ImmutableList.of(testLocation));
-        EntityTestUtils.assertAttributeEqualsEventually(ImmutableMap.of("timeout", 10*60*1000), activeMQ, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(ImmutableMap.of("timeout", 10*60*1000), activeMQ, Startable.SERVICE_UP, true);
         log.info("JMX URL is "+activeMQ.getAttribute(UsesJmx.JMX_URL));
         activeMQ.stop();
         assertFalse(activeMQ.getAttribute(Startable.SERVICE_UP));
@@ -95,7 +95,7 @@ public class ActiveMQIntegrationTest {
             .configure("jmxPort", "11099+"));
        
         activeMQ.start(ImmutableList.of(testLocation));
-        EntityTestUtils.assertAttributeEqualsEventually(ImmutableMap.of("timeout", 10*60*1000), activeMQ, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(ImmutableMap.of("timeout", 10*60*1000), activeMQ, Startable.SERVICE_UP, true);
         log.info("JMX URL is "+activeMQ.getAttribute(UsesJmx.JMX_URL));
         activeMQ.stop();
         assertFalse(activeMQ.getAttribute(Startable.SERVICE_UP));
@@ -108,7 +108,7 @@ public class ActiveMQIntegrationTest {
             .configure("brokerName", "bridge"));
 
         activeMQ.start(ImmutableList.of(testLocation));
-        EntityTestUtils.assertAttributeEqualsEventually(ImmutableMap.of("timeout", 10*60*1000), activeMQ, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(ImmutableMap.of("timeout", 10*60*1000), activeMQ, Startable.SERVICE_UP, true);
         log.info("JMX URL is "+activeMQ.getAttribute(UsesJmx.JMX_URL));
         activeMQ.stop();
         assertFalse(activeMQ.getAttribute(Startable.SERVICE_UP));
@@ -121,11 +121,11 @@ public class ActiveMQIntegrationTest {
         ActiveMQBroker activeMQ2 = app.createAndManageChild(EntitySpec.create(ActiveMQBroker.class));
 
         activeMQ1.start(ImmutableList.of(testLocation));
-        EntityTestUtils.assertAttributeEqualsEventually(ImmutableMap.of("timeout", 10*60*1000), activeMQ1, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(ImmutableMap.of("timeout", 10 * 60 * 1000), activeMQ1, Startable.SERVICE_UP, true);
         log.info("JMX URL is "+activeMQ1.getAttribute(UsesJmx.JMX_URL));
 
         activeMQ2.start(ImmutableList.of(testLocation));
-        EntityTestUtils.assertAttributeEqualsEventually(ImmutableMap.of("timeout", 10*60*1000), activeMQ2, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(ImmutableMap.of("timeout", 10*60*1000), activeMQ2, Startable.SERVICE_UP, true);
         log.info("JMX URL is "+activeMQ2.getAttribute(UsesJmx.JMX_URL));
     }
 
@@ -176,7 +176,7 @@ public class ActiveMQIntegrationTest {
             .configure(UsesJmx.JMX_AGENT_MODE, mode));
         
         activeMQ.start(ImmutableList.of(testLocation));
-        EntityTestUtils.assertAttributeEqualsEventually(ImmutableMap.of("timeout", 10*60*1000), activeMQ, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(ImmutableMap.of("timeout", 10 * 60 * 1000), activeMQ, Startable.SERVICE_UP, true);
 
         String jmxUrl = activeMQ.getAttribute(UsesJmx.JMX_URL);
         log.info("JMX URL ("+mode+") is "+jmxUrl);
@@ -198,16 +198,16 @@ public class ActiveMQIntegrationTest {
             // Connect to broker using JMS and send messages
             Connection connection = getActiveMQConnection(activeMQ);
             clearQueue(connection, queueName);
-            EntityTestUtils.assertAttributeEqualsEventually(queue, ActiveMQQueue.QUEUE_DEPTH_MESSAGES, 0);
+            EntityAsserts.assertAttributeEqualsEventually(queue, ActiveMQQueue.QUEUE_DEPTH_MESSAGES, 0);
             sendMessages(connection, number, queueName, content);
             // Check messages arrived
-            EntityTestUtils.assertAttributeEqualsEventually(queue, ActiveMQQueue.QUEUE_DEPTH_MESSAGES, number);
+            EntityAsserts.assertAttributeEqualsEventually(queue, ActiveMQQueue.QUEUE_DEPTH_MESSAGES, number);
 
             // Clear the messages
             assertEquals(clearQueue(connection, queueName), number);
 
             // Check messages cleared
-            EntityTestUtils.assertAttributeEqualsEventually(queue, ActiveMQQueue.QUEUE_DEPTH_MESSAGES, 0);
+            EntityAsserts.assertAttributeEqualsEventually(queue, ActiveMQQueue.QUEUE_DEPTH_MESSAGES, 0);
 
             connection.close();
 

--- a/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/kafka/KafkaIntegrationTest.java
+++ b/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/kafka/KafkaIntegrationTest.java
@@ -28,11 +28,11 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.time.Duration;
 import org.testng.annotations.AfterMethod;
@@ -74,7 +74,7 @@ public class KafkaIntegrationTest {
         final KafkaZooKeeper zookeeper = app.createAndManageChild(EntitySpec.create(KafkaZooKeeper.class));
 
         zookeeper.start(ImmutableList.of(testLocation));
-        EntityTestUtils.assertAttributeEqualsEventually(ImmutableMap.of("timeout", 60*1000), zookeeper, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(ImmutableMap.of("timeout", 60*1000), zookeeper, Startable.SERVICE_UP, true);
 
         zookeeper.stop();
         assertFalse(zookeeper.getAttribute(Startable.SERVICE_UP));
@@ -89,10 +89,10 @@ public class KafkaIntegrationTest {
         final KafkaBroker broker = app.createAndManageChild(EntitySpec.create(KafkaBroker.class).configure(KafkaBroker.ZOOKEEPER, zookeeper));
 
         zookeeper.start(ImmutableList.of(testLocation));
-        EntityTestUtils.assertAttributeEqualsEventually(ImmutableMap.of("timeout", 60*1000), zookeeper, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(ImmutableMap.of("timeout", 60 * 1000), zookeeper, Startable.SERVICE_UP, true);
 
         broker.start(ImmutableList.of(testLocation));
-        EntityTestUtils.assertAttributeEqualsEventually(ImmutableMap.of("timeout", 60*1000), broker, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(ImmutableMap.of("timeout", 60*1000), broker, Startable.SERVICE_UP, true);
 
         zookeeper.stop();
         assertFalse(zookeeper.getAttribute(Startable.SERVICE_UP));

--- a/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/qpid/QpidEc2LiveTest.java
+++ b/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/qpid/QpidEc2LiveTest.java
@@ -20,8 +20,8 @@ package org.apache.brooklyn.entity.messaging.qpid;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -37,7 +37,7 @@ public class QpidEc2LiveTest extends AbstractEc2LiveTest {
                 .configure("rmiRegistryPort", "9910+"));
         
         qpid.start(ImmutableList.of(loc));
-        EntityTestUtils.assertAttributeEqualsEventually(qpid, QpidBroker.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(qpid, QpidBroker.SERVICE_UP, true);
     }
     
     @Test(enabled=false)

--- a/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/qpid/QpidIntegrationTest.java
+++ b/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/qpid/QpidIntegrationTest.java
@@ -37,12 +37,12 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.test.HttpTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.exceptions.Exceptions;
@@ -88,7 +88,7 @@ public class QpidIntegrationTest {
                 .configure("jmxPort", "9909+")
                 .configure("rmiRegistryPort", "9910+"));
         qpid.start(ImmutableList.of(testLocation));
-        EntityTestUtils.assertAttributeEqualsEventually(qpid, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(qpid, Startable.SERVICE_UP, true);
         qpid.stop();
         assertFalse(qpid.getAttribute(Startable.SERVICE_UP));
     }
@@ -101,7 +101,7 @@ public class QpidIntegrationTest {
         qpid = app.createAndManageChild(EntitySpec.create(QpidBroker.class)
                 .configure("httpManagementPort", "8888+"));
         qpid.start(ImmutableList.of(testLocation));
-        EntityTestUtils.assertAttributeEqualsEventually(qpid, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(qpid, Startable.SERVICE_UP, true);
         String httpUrl = "http://"+qpid.getAttribute(QpidBroker.HOSTNAME)+":"+qpid.getAttribute(QpidBroker.HTTP_MANAGEMENT_PORT)+"/management";
         HttpTestUtils.assertHttpStatusCodeEventuallyEquals(httpUrl, 200);
         // TODO check actual REST output
@@ -126,7 +126,7 @@ public class QpidIntegrationTest {
                 .configure(SoftwareProcess.RUNTIME_FILES, qpidRuntimeFiles)
                 .configure(QpidBroker.SUGGESTED_VERSION, "0.14"));
         qpid.start(ImmutableList.of(testLocation));
-        EntityTestUtils.assertAttributeEqualsEventually(qpid, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(qpid, Startable.SERVICE_UP, true);
         qpid.stop();
         assertFalse(qpid.getAttribute(Startable.SERVICE_UP));
     }
@@ -151,7 +151,7 @@ public class QpidIntegrationTest {
         qpid = app.createAndManageChild(EntitySpec.create(QpidBroker.class)
                 .configure("queue", queueName));
         qpid.start(ImmutableList.of(testLocation));
-        EntityTestUtils.assertAttributeEqualsEventually(qpid, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(qpid, Startable.SERVICE_UP, true);
 
         try {
             // Check queue created

--- a/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/rabbit/RabbitEc2LiveTest.java
+++ b/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/rabbit/RabbitEc2LiveTest.java
@@ -30,7 +30,6 @@ import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
 import org.apache.brooklyn.entity.messaging.MessageBroker;
 import org.apache.brooklyn.entity.messaging.amqp.AmqpExchange;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.SkipException;
@@ -53,7 +52,7 @@ public class RabbitEc2LiveTest extends AbstractEc2LiveTest {
     protected void doTest(Location loc) throws Exception {
         RabbitBroker rabbit = app.createAndManageChild(EntitySpec.create(RabbitBroker.class));
         rabbit.start(ImmutableList.of(loc));
-        EntityTestUtils.assertAttributeEqualsEventually(rabbit, RabbitBroker.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(rabbit, RabbitBroker.SERVICE_UP, true);
 
         byte[] content = "MessageBody".getBytes(Charsets.UTF_8);
         String queue = "queueName";

--- a/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/rabbit/RabbitIntegrationTest.java
+++ b/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/rabbit/RabbitIntegrationTest.java
@@ -26,10 +26,10 @@ import java.io.IOException;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -87,7 +87,7 @@ public class RabbitIntegrationTest {
     public void canStartupAndShutdown() throws Exception {
         rabbit = app.createAndManageChild(EntitySpec.create(RabbitBroker.class));
         rabbit.start(ImmutableList.of(testLocation));
-        EntityTestUtils.assertAttributeEqualsEventually(rabbit, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(rabbit, Startable.SERVICE_UP, true);
         rabbit.stop();
         assertFalse(rabbit.getAttribute(Startable.SERVICE_UP));
     }
@@ -99,7 +99,7 @@ public class RabbitIntegrationTest {
     public void testClientConnection() throws Exception {
         rabbit = app.createAndManageChild(EntitySpec.create(RabbitBroker.class));
         rabbit.start(ImmutableList.of(testLocation));
-        EntityTestUtils.assertAttributeEqualsEventually(rabbit, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(rabbit, Startable.SERVICE_UP, true);
 
         byte[] content = "MessageBody".getBytes(Charsets.UTF_8);
         String queue = "queueName";

--- a/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/storm/StormAbstractCloudLiveTest.java
+++ b/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/storm/StormAbstractCloudLiveTest.java
@@ -32,10 +32,10 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.ResourceUtils;
 import org.apache.brooklyn.util.core.file.ArchiveBuilder;
@@ -119,11 +119,11 @@ public abstract class StormAbstractCloudLiveTest extends BrooklynAppLiveTestSupp
             log.info("Started Storm deployment on '" + getLocation() + "'");
             app.start(ImmutableList.of(location));
             Entities.dumpInfo(app);
-            EntityTestUtils.assertAttributeEqualsEventually(app, Startable.SERVICE_UP, true);
-            EntityTestUtils.assertAttributeEqualsEventually(zooKeeperEnsemble, Startable.SERVICE_UP, true);
-            EntityTestUtils.assertAttributeEqualsEventually(nimbus, Startable.SERVICE_UP, true);
-            EntityTestUtils.assertAttributeEqualsEventually(supervisor, Startable.SERVICE_UP, true);
-            EntityTestUtils.assertAttributeEqualsEventually(ui, Startable.SERVICE_UP, true);
+            EntityAsserts.assertAttributeEqualsEventually(app, Startable.SERVICE_UP, true);
+            EntityAsserts.assertAttributeEqualsEventually(zooKeeperEnsemble, Startable.SERVICE_UP, true);
+            EntityAsserts.assertAttributeEqualsEventually(nimbus, Startable.SERVICE_UP, true);
+            EntityAsserts.assertAttributeEqualsEventually(supervisor, Startable.SERVICE_UP, true);
+            EntityAsserts.assertAttributeEqualsEventually(ui, Startable.SERVICE_UP, true);
             
             StormTopology stormTopology = createTopology();
             submitTopology(stormTopology, "myExclamation", 3, true, 60000);

--- a/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/storm/StormEc2LiveTest.java
+++ b/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/storm/StormEc2LiveTest.java
@@ -21,8 +21,8 @@ package org.apache.brooklyn.entity.messaging.storm;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.Test;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
 import org.apache.brooklyn.entity.zookeeper.ZooKeeperNode;
@@ -45,11 +45,11 @@ public class StormEc2LiveTest extends AbstractEc2LiveTest {
                 Storm.Role.UI));        
         app.start(ImmutableList.of(loc));
         Entities.dumpInfo(app);
-        
-        EntityTestUtils.assertAttributeEqualsEventually(zookeeper, Startable.SERVICE_UP, true);
-        EntityTestUtils.assertAttributeEqualsEventually(nimbus, Startable.SERVICE_UP, true);
-        EntityTestUtils.assertAttributeEqualsEventually(supervisor, Startable.SERVICE_UP, true);
-        EntityTestUtils.assertAttributeEqualsEventually(ui, Startable.SERVICE_UP, true);
+
+        EntityAsserts.assertAttributeEqualsEventually(zookeeper, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(nimbus, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(supervisor, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(ui, Startable.SERVICE_UP, true);
     }
 
     @Test(enabled=false)

--- a/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/zookeeper/ZooKeeperEc2LiveTest.java
+++ b/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/zookeeper/ZooKeeperEc2LiveTest.java
@@ -21,8 +21,8 @@ package org.apache.brooklyn.entity.messaging.zookeeper;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.Test;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
 import org.apache.brooklyn.entity.zookeeper.ZooKeeperNode;
@@ -39,7 +39,7 @@ public class ZooKeeperEc2LiveTest extends AbstractEc2LiveTest {
         ZooKeeperNode zookeeper = app.createAndManageChild(EntitySpec.create(ZooKeeperNode.class).configure("jmxPort", "31001+"));
         app.start(ImmutableList.of(loc));
         Entities.dumpInfo(zookeeper);
-        EntityTestUtils.assertAttributeEqualsEventually(zookeeper, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(zookeeper, Startable.SERVICE_UP, true);
     }
     
     @Test(enabled=false)

--- a/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/zookeeper/ZooKeeperEnsembleLiveTest.java
+++ b/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/zookeeper/ZooKeeperEnsembleLiveTest.java
@@ -20,6 +20,7 @@ package org.apache.brooklyn.entity.messaging.zookeeper;
 
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.test.entity.TestApplication;
@@ -33,7 +34,6 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -90,17 +90,17 @@ public class ZooKeeperEnsembleLiveTest {
 
             app.start(ImmutableList.of(testLocation));
 
-            EntityTestUtils.assertAttributeEqualsEventually(cluster, ZooKeeperEnsemble.GROUP_SIZE, 3);
+            EntityAsserts.assertAttributeEqualsEventually(cluster, ZooKeeperEnsemble.GROUP_SIZE, 3);
             Entities.dumpInfo(app);
 
-            EntityTestUtils.assertAttributeEqualsEventually(cluster, Startable.SERVICE_UP, true);
+            EntityAsserts.assertAttributeEqualsEventually(cluster, Startable.SERVICE_UP, true);
             for(Entity zkNode : cluster.getMembers()) {
                 assertTrue(isSocketOpen((ZooKeeperNode) zkNode));
             }
             cluster.resize(1);
-            EntityTestUtils.assertAttributeEqualsEventually(cluster, ZooKeeperEnsemble.GROUP_SIZE, 1);
+            EntityAsserts.assertAttributeEqualsEventually(cluster, ZooKeeperEnsemble.GROUP_SIZE, 1);
             Entities.dumpInfo(app);
-            EntityTestUtils.assertAttributeEqualsEventually(cluster, Startable.SERVICE_UP, true);
+            EntityAsserts.assertAttributeEqualsEventually(cluster, Startable.SERVICE_UP, true);
             for (Entity zkNode : cluster.getMembers()) {
                 assertTrue(isSocketOpen((ZooKeeperNode) zkNode));
             }

--- a/software/monitoring/src/test/java/org/apache/brooklyn/entity/monitoring/monit/MonitIntegrationTest.java
+++ b/software/monitoring/src/test/java/org/apache/brooklyn/entity/monitoring/monit/MonitIntegrationTest.java
@@ -29,7 +29,7 @@ import java.util.concurrent.Callable;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.MachineDetails;
-import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.sensor.DependentConfiguration;
 import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
 import org.apache.brooklyn.entity.database.mysql.MySqlNode;
@@ -37,7 +37,6 @@ import org.apache.brooklyn.entity.software.base.SameServerEntity;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -81,7 +80,7 @@ public class MonitIntegrationTest extends BrooklynAppLiveTestSupport {
             .configure(MonitNode.CONTROL_FILE_URL, "classpath:///org/apache/brooklyn/entity/monitoring/monit/monit.monitrc"));
         app.start(ImmutableSet.of(loc));
         LOG.info("Monit started");
-        EntityTestUtils.assertAttributeEqualsEventually(monitNode, MonitNode.MONIT_TARGET_PROCESS_STATUS, "Running");
+        EntityAsserts.assertAttributeEqualsEventually(monitNode, MonitNode.MONIT_TARGET_PROCESS_STATUS, "Running");
     }
     
     @Test(groups = "Integration")
@@ -102,7 +101,7 @@ public class MonitIntegrationTest extends BrooklynAppLiveTestSupport {
 
         app.start(ImmutableSet.of(loc));
         LOG.info("Monit and MySQL started");
-        EntityTestUtils.assertAttributeEqualsEventually(monitNode, MonitNode.MONIT_TARGET_PROCESS_STATUS, "Running");
+        EntityAsserts.assertAttributeEqualsEventually(monitNode, MonitNode.MONIT_TARGET_PROCESS_STATUS, "Running");
         mySqlNode.stop();
         Asserts.succeedsEventually(new Runnable() {
             @Override
@@ -113,7 +112,7 @@ public class MonitIntegrationTest extends BrooklynAppLiveTestSupport {
             }
         });
         mySqlNode.restart();
-        EntityTestUtils.assertAttributeEqualsEventually(monitNode, MonitNode.MONIT_TARGET_PROCESS_STATUS, "Running");
+        EntityAsserts.assertAttributeEqualsEventually(monitNode, MonitNode.MONIT_TARGET_PROCESS_STATUS, "Running");
     }
     
     @Test(groups = "Integration")
@@ -181,7 +180,7 @@ public class MonitIntegrationTest extends BrooklynAppLiveTestSupport {
             }
         });
         mySqlNode.stop();
-        EntityTestUtils.assertAttributeEqualsEventually(monitNode, MonitNode.MONIT_TARGET_PROCESS_STATUS, "Running");
+        EntityAsserts.assertAttributeEqualsEventually(monitNode, MonitNode.MONIT_TARGET_PROCESS_STATUS, "Running");
 
         // NOTE: Do not manually restart the mySqlNode, it should be restarted by monit
         Asserts.succeedsEventually(new Runnable() {

--- a/software/network/src/test/java/org/apache/brooklyn/entity/network/bind/BindDnsServerLiveTest.java
+++ b/software/network/src/test/java/org/apache/brooklyn/entity/network/bind/BindDnsServerLiveTest.java
@@ -18,14 +18,13 @@
  */
 package org.apache.brooklyn.entity.network.bind;
 
-import static org.apache.brooklyn.test.EntityTestUtils.assertAttributeEqualsEventually;
 import static org.testng.Assert.assertEquals;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.sensor.EnricherSpec;
 import org.apache.brooklyn.core.entity.Attributes;
-import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.group.DynamicCluster;
 import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
@@ -61,7 +60,7 @@ public class BindDnsServerLiveTest {
                 .configure(BindDnsServer.HOSTNAME_SENSOR, PrefixAndIdEnricher.SENSOR)));
 
         app.start(ImmutableList.of(testLocation));
-        assertAttributeEqualsEventually(dns, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(dns, Attributes.SERVICE_UP, true);
 
         logDnsMappings(dns);
         assertEquals(dns.getAttribute(BindDnsServer.ADDRESS_MAPPINGS).entries().size(), 1);

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraDatacenterIntegrationTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraDatacenterIntegrationTest.java
@@ -27,11 +27,11 @@ import java.math.BigInteger;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
 import org.apache.brooklyn.entity.nosql.cassandra.TokenGenerators.PosNeg63TokenGenerator;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -113,15 +113,15 @@ public class CassandraDatacenterIntegrationTest extends BrooklynAppLiveTestSuppo
         
         final CassandraNode node = (CassandraNode) Iterables.get(cluster.getMembers(), 0);
         String nodeAddr = checkNotNull(node.getAttribute(CassandraNode.HOSTNAME), "hostname") + ":" + checkNotNull(node.getAttribute(CassandraNode.THRIFT_PORT), "thriftPort");
-        
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, CassandraDatacenter.GROUP_SIZE, 1);
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, CassandraDatacenter.CASSANDRA_CLUSTER_NODES, ImmutableList.of(nodeAddr));
 
-        EntityTestUtils.assertAttributeEqualsEventually(node, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, CassandraDatacenter.GROUP_SIZE, 1);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, CassandraDatacenter.CASSANDRA_CLUSTER_NODES, ImmutableList.of(nodeAddr));
+
+        EntityAsserts.assertAttributeEqualsEventually(node, Startable.SERVICE_UP, true);
         if (assertToken) {
             PosNeg63TokenGenerator tg = new PosNeg63TokenGenerator();
             tg.growingCluster(1);
-            EntityTestUtils.assertAttributeEqualsEventually(node, CassandraNode.TOKENS, ImmutableSet.of(tg.newToken().add(BigInteger.valueOf(42))));
+            EntityAsserts.assertAttributeEqualsEventually(node, CassandraNode.TOKENS, ImmutableSet.of(tg.newToken().add(BigInteger.valueOf(42))));
         }
 
         // may take some time to be consistent (with new thrift_latency checks on the node,

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraDatacenterLiveTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraDatacenterLiveTest.java
@@ -35,11 +35,11 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
 import org.apache.brooklyn.entity.nosql.cassandra.AstyanaxSupport.AstyanaxSample;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.text.Identifiers;
 import org.apache.brooklyn.util.time.Duration;
@@ -149,7 +149,7 @@ public class CassandraDatacenterLiveTest extends BrooklynAppLiveTestSupport {
         app.start(ImmutableList.of(testLocation));
 
         // Check cluster is up and healthy
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, CassandraDatacenter.GROUP_SIZE, 2);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, CassandraDatacenter.GROUP_SIZE, 2);
         Entities.dumpInfo(app);
         List<CassandraNode> members = castToCassandraNodes(cluster.getMembers());
         assertNodesConsistent(members);
@@ -190,11 +190,11 @@ public class CassandraDatacenterLiveTest extends BrooklynAppLiveTestSupport {
             public void run() {
                 for (Entity n : nodes) {
                     CassandraNode node = (CassandraNode) n;
-                    EntityTestUtils.assertAttributeEquals(node, Startable.SERVICE_UP, true);
+                    EntityAsserts.assertAttributeEquals(node, Startable.SERVICE_UP, true);
                     String errmsg = "node="+node+"; hostname="+node.getAttribute(Attributes.HOSTNAME)+"; port="+node.getThriftPort();
                     assertTrue(isSocketOpen(node), errmsg);
                     assertTrue(areVersionsConsistent(node), errmsg);
-                    EntityTestUtils.assertAttributeEquals(node, CassandraNode.LIVE_NODE_COUNT, expectedLiveNodeCount);
+                    EntityAsserts.assertAttributeEquals(node, CassandraNode.LIVE_NODE_COUNT, expectedLiveNodeCount);
                 }
             }});
     }
@@ -205,9 +205,9 @@ public class CassandraDatacenterLiveTest extends BrooklynAppLiveTestSupport {
             public void run() {
                 Set<BigInteger> alltokens = Sets.newLinkedHashSet();
                 for (Entity node : nodes) {
-                    EntityTestUtils.assertAttributeEquals(node, Startable.SERVICE_UP, true);
-                    EntityTestUtils.assertConfigEquals(node, CassandraNode.NUM_TOKENS_PER_NODE, 1);
-                    EntityTestUtils.assertAttributeEquals(node, CassandraNode.PEERS, numNodes);
+                    EntityAsserts.assertAttributeEquals(node, Startable.SERVICE_UP, true);
+                    EntityAsserts.assertConfigEquals(node, CassandraNode.NUM_TOKENS_PER_NODE, 1);
+                    EntityAsserts.assertAttributeEquals(node, CassandraNode.PEERS, numNodes);
                     Set<BigInteger> tokens = node.getAttribute(CassandraNode.TOKENS);
                     assertNotNull(tokens);
                     alltokens.addAll(tokens);
@@ -225,9 +225,9 @@ public class CassandraDatacenterLiveTest extends BrooklynAppLiveTestSupport {
             public void run() {
                 Set<BigInteger> alltokens = Sets.newLinkedHashSet();
                 for (Entity node : nodes) {
-                    EntityTestUtils.assertAttributeEquals(node, Startable.SERVICE_UP, true);
-                    EntityTestUtils.assertAttributeEquals(node, CassandraNode.PEERS, tokensPerNode*numNodes);
-                    EntityTestUtils.assertConfigEquals(node, CassandraNode.NUM_TOKENS_PER_NODE, 256);
+                    EntityAsserts.assertAttributeEquals(node, Startable.SERVICE_UP, true);
+                    EntityAsserts.assertAttributeEquals(node, CassandraNode.PEERS, tokensPerNode*numNodes);
+                    EntityAsserts.assertConfigEquals(node, CassandraNode.NUM_TOKENS_PER_NODE, 256);
                     Set<BigInteger> tokens = node.getAttribute(CassandraNode.TOKENS);
                     assertNotNull(tokens);
                     assertEquals(tokens.size(), tokensPerNode, "tokens="+tokens);

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraDatacenterRebindIntegrationTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraDatacenterRebindIntegrationTest.java
@@ -25,11 +25,11 @@ import java.math.BigInteger;
 import java.util.Set;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.mgmt.rebind.RebindOptions;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
 import org.apache.brooklyn.entity.proxy.nginx.NginxController;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterMethod;
@@ -75,7 +75,7 @@ public class CassandraDatacenterRebindIntegrationTest extends RebindTestFixtureW
         origApp.start(ImmutableList.of(localhostProvisioningLocation));
         CassandraNode origNode = (CassandraNode) Iterables.get(origDatacenter.getMembers(), 0);
 
-        EntityTestUtils.assertAttributeEqualsEventually(origDatacenter, CassandraDatacenter.GROUP_SIZE, 1);
+        EntityAsserts.assertAttributeEqualsEventually(origDatacenter, CassandraDatacenter.GROUP_SIZE, 1);
         CassandraDatacenterLiveTest.assertNodesConsistent(ImmutableList.of(origNode));
         CassandraDatacenterLiveTest.assertSingleTokenConsistent(ImmutableList.of(origNode));
         CassandraDatacenterLiveTest.checkConnectionRepeatedly(2, 5, ImmutableList.of(origNode));
@@ -87,9 +87,9 @@ public class CassandraDatacenterRebindIntegrationTest extends RebindTestFixtureW
         final CassandraDatacenter newDatacenter = (CassandraDatacenter) Iterables.find(newApp.getChildren(), Predicates.instanceOf(CassandraDatacenter.class));
         final CassandraNode newNode = (CassandraNode) Iterables.find(newDatacenter.getMembers(), Predicates.instanceOf(CassandraNode.class));
         
-        EntityTestUtils.assertAttributeEqualsEventually(newDatacenter, CassandraDatacenter.GROUP_SIZE, 1);
-        EntityTestUtils.assertAttributeEqualsEventually(newNode, Startable.SERVICE_UP, true);
-        EntityTestUtils.assertAttributeEqualsEventually(newNode, CassandraNode.TOKENS, origTokens);
+        EntityAsserts.assertAttributeEqualsEventually(newDatacenter, CassandraDatacenter.GROUP_SIZE, 1);
+        EntityAsserts.assertAttributeEqualsEventually(newNode, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(newNode, CassandraNode.TOKENS, origTokens);
         CassandraDatacenterLiveTest.assertNodesConsistent(ImmutableList.of(newNode));
         CassandraDatacenterLiveTest.assertSingleTokenConsistent(ImmutableList.of(newNode));
         CassandraDatacenterLiveTest.checkConnectionRepeatedly(2, 5, ImmutableList.of(newNode));

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraFabricTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraFabricTest.java
@@ -31,13 +31,13 @@ import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.core.entity.AbstractEntity;
 import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.entity.lifecycle.ServiceStateLogic;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.entity.software.base.EmptySoftwareProcess;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -93,9 +93,9 @@ public class CassandraFabricTest extends BrooklynAppUnitTestSupport {
                         Sets.intersection(input, ImmutableSet.of(d2a, d2b)).size() == 1;
             }
         };
-        EntityTestUtils.assertAttributeEventually(fabric, CassandraFabric.CURRENT_SEEDS, predicate);
-        EntityTestUtils.assertAttributeEventually(d1, CassandraDatacenter.CURRENT_SEEDS, predicate);
-        EntityTestUtils.assertAttributeEventually(d2, CassandraDatacenter.CURRENT_SEEDS, predicate);
+        EntityAsserts.assertAttributeEventually(fabric, CassandraFabric.CURRENT_SEEDS, predicate);
+        EntityAsserts.assertAttributeEventually(d1, CassandraDatacenter.CURRENT_SEEDS, predicate);
+        EntityAsserts.assertAttributeEventually(d2, CassandraDatacenter.CURRENT_SEEDS, predicate);
         
         Set<Entity> seeds = fabric.getAttribute(CassandraFabric.CURRENT_SEEDS);
         assertEquals(d1.getAttribute(CassandraDatacenter.CURRENT_SEEDS), seeds);
@@ -119,15 +119,15 @@ public class CassandraFabricTest extends BrooklynAppUnitTestSupport {
         };
         t.start();
         try {
-            EntityTestUtils.assertGroupSizeEqualsEventually(fabric, 2);
+            EntityAsserts.assertGroupSizeEqualsEventually(fabric, 2);
             CassandraDatacenter d1 = (CassandraDatacenter) Iterables.get(fabric.getMembers(), 0);
             CassandraDatacenter d2 = (CassandraDatacenter) Iterables.get(fabric.getMembers(), 1);
     
-            EntityTestUtils.assertGroupSizeEqualsEventually(d1, 2);
+            EntityAsserts.assertGroupSizeEqualsEventually(d1, 2);
             final DummyCassandraNode d1a = (DummyCassandraNode) Iterables.get(d1.getMembers(), 0);
             final DummyCassandraNode d1b = (DummyCassandraNode) Iterables.get(d1.getMembers(), 1);
     
-            EntityTestUtils.assertGroupSizeEqualsEventually(d2, 2);
+            EntityAsserts.assertGroupSizeEqualsEventually(d2, 2);
             final DummyCassandraNode d2a = (DummyCassandraNode) Iterables.get(d2.getMembers(), 0);
             final DummyCassandraNode d2b = (DummyCassandraNode) Iterables.get(d2.getMembers(), 1);
 
@@ -145,9 +145,9 @@ public class CassandraFabricTest extends BrooklynAppUnitTestSupport {
                             Sets.intersection(input, ImmutableSet.of(d2a, d2b)).size() == 1;
                 }
             };
-            EntityTestUtils.assertAttributeEventually(fabric, CassandraFabric.CURRENT_SEEDS, predicate);
-            EntityTestUtils.assertAttributeEventually(d1, CassandraDatacenter.CURRENT_SEEDS, predicate);
-            EntityTestUtils.assertAttributeEventually(d2, CassandraDatacenter.CURRENT_SEEDS, predicate);
+            EntityAsserts.assertAttributeEventually(fabric, CassandraFabric.CURRENT_SEEDS, predicate);
+            EntityAsserts.assertAttributeEventually(d1, CassandraDatacenter.CURRENT_SEEDS, predicate);
+            EntityAsserts.assertAttributeEventually(d2, CassandraDatacenter.CURRENT_SEEDS, predicate);
             
             Set<Entity> seeds = fabric.getAttribute(CassandraFabric.CURRENT_SEEDS);
             assertEquals(d1.getAttribute(CassandraDatacenter.CURRENT_SEEDS), seeds);

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraNodeEc2LiveTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraNodeEc2LiveTest.java
@@ -28,7 +28,6 @@ import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
 import org.apache.brooklyn.entity.nosql.cassandra.AstyanaxSupport.AstyanaxSample;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
@@ -49,7 +48,7 @@ public class CassandraNodeEc2LiveTest extends AbstractEc2LiveTest {
                 .configure("clusterName", "TestCluster"));
         app.start(ImmutableList.of(loc));
 
-        EntityTestUtils.assertAttributeEqualsEventually(cassandra, CassandraNode.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(cassandra, CassandraNode.SERVICE_UP, true);
 
         AstyanaxSample astyanax = new AstyanaxSample(cassandra);
         astyanax.astyanaxTest();

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraNodeIntegrationTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraNodeIntegrationTest.java
@@ -27,12 +27,11 @@ import java.util.Map;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.sensor.PortAttributeSensorAndConfigKey;
-import org.apache.brooklyn.entity.nosql.cassandra.CassandraNode;
 import org.apache.brooklyn.entity.nosql.cassandra.AstyanaxSupport.AstyanaxSample;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.test.NetworkingTestUtils;
 import org.apache.brooklyn.util.math.MathPredicates;
 import org.slf4j.Logger;
@@ -97,12 +96,12 @@ public class CassandraNodeIntegrationTest extends AbstractCassandraNodeTest {
                 .configure("rmiRegistryPort", "19001+"));
         app.start(ImmutableList.of(testLocation));
 
-        EntityTestUtils.assertAttributeEqualsEventually(cassandra, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(cassandra, Startable.SERVICE_UP, true);
         Entities.dumpInfo(app);
 
         cassandra.stop();
 
-        EntityTestUtils.assertAttributeEqualsEventually(cassandra, Startable.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(cassandra, Startable.SERVICE_UP, false);
     }
 
     /**
@@ -116,7 +115,7 @@ public class CassandraNodeIntegrationTest extends AbstractCassandraNodeTest {
                 .configure("thriftPort", "9876+"));
         app.start(ImmutableList.of(testLocation));
 
-        EntityTestUtils.assertAttributeEqualsEventually(cassandra, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(cassandra, Startable.SERVICE_UP, true);
 
         AstyanaxSample astyanax = new AstyanaxSample(cassandra);
         astyanax.astyanaxTest();
@@ -145,7 +144,7 @@ public class CassandraNodeIntegrationTest extends AbstractCassandraNodeTest {
                 .configure("rmiRegistryPort", "19001+"));
         app.start(ImmutableList.of(testLocation));
 
-        EntityTestUtils.assertAttributeEqualsEventually(cassandra, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(cassandra, Startable.SERVICE_UP, true);
         Entities.dumpInfo(app);
 
         AstyanaxSample astyanax = new AstyanaxSample(cassandra);
@@ -166,10 +165,10 @@ public class CassandraNodeIntegrationTest extends AbstractCassandraNodeTest {
         
                 assertNotNull(cassandra.getAttribute(CassandraNode.READ_PENDING));
                 assertNotNull(cassandra.getAttribute(CassandraNode.READ_ACTIVE));
-                EntityTestUtils.assertAttribute(cassandra, CassandraNode.READ_COMPLETED, MathPredicates.greaterThanOrEqual(1));
+                EntityAsserts.assertAttribute(cassandra, CassandraNode.READ_COMPLETED, MathPredicates.greaterThanOrEqual(1));
                 assertNotNull(cassandra.getAttribute(CassandraNode.WRITE_PENDING));
                 assertNotNull(cassandra.getAttribute(CassandraNode.WRITE_ACTIVE));
-                EntityTestUtils.assertAttribute(cassandra, CassandraNode.WRITE_COMPLETED, MathPredicates.greaterThanOrEqual(1));
+                EntityAsserts.assertAttribute(cassandra, CassandraNode.WRITE_COMPLETED, MathPredicates.greaterThanOrEqual(1));
                 
                 assertNotNull(cassandra.getAttribute(CassandraNode.READS_PER_SECOND_LAST));
                 assertNotNull(cassandra.getAttribute(CassandraNode.WRITES_PER_SECOND_LAST));
@@ -179,11 +178,11 @@ public class CassandraNodeIntegrationTest extends AbstractCassandraNodeTest {
                 assertNotNull(cassandra.getAttribute(CassandraNode.WRITES_PER_SECOND_IN_WINDOW));
                 
                 // an example MXBean
-                EntityTestUtils.assertAttribute(cassandra, CassandraNode.MAX_HEAP_MEMORY, MathPredicates.greaterThanOrEqual(1));
+                EntityAsserts.assertAttribute(cassandra, CassandraNode.MAX_HEAP_MEMORY, MathPredicates.greaterThanOrEqual(1));
             }});
 
         cassandra.stop();
 
-        EntityTestUtils.assertAttributeEqualsEventually(cassandra, Startable.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(cassandra, Startable.SERVICE_UP, false);
     }
 }

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraNodeLiveTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraNodeLiveTest.java
@@ -21,9 +21,8 @@ package org.apache.brooklyn.entity.nosql.cassandra;
 import java.util.Map;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
-import org.apache.brooklyn.entity.nosql.cassandra.CassandraNode;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.entity.nosql.cassandra.AstyanaxSupport.AstyanaxSample;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
@@ -66,7 +65,7 @@ public class CassandraNodeLiveTest extends AbstractCassandraNodeTest {
                 .configure("thriftPort", "9876+")
                 .configure("clusterName", "TestCluster"));
         app.start(ImmutableList.of(testLocation));
-        EntityTestUtils.assertAttributeEqualsEventually(cassandra, CassandraNode.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(cassandra, CassandraNode.SERVICE_UP, true);
 
         AstyanaxSample astyanax = new AstyanaxSample(cassandra);
         astyanax.astyanaxTest();

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/couchbase/CouchbaseSyncGatewayEc2LiveTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/couchbase/CouchbaseSyncGatewayEc2LiveTest.java
@@ -23,10 +23,10 @@ import java.util.Map;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
 import org.apache.brooklyn.entity.group.DynamicCluster;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -67,8 +67,8 @@ public class CouchbaseSyncGatewayEc2LiveTest extends AbstractEc2LiveTest {
         );
         
         app.start(ImmutableList.of(loc));
-        
-        EntityTestUtils.assertAttributeEqualsEventually(gateway, Startable.SERVICE_UP, true);
+
+        EntityAsserts.assertAttributeEqualsEventually(gateway, Startable.SERVICE_UP, true);
     }
     
     

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/couchdb/CouchDBClusterLiveTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/couchdb/CouchDBClusterLiveTest.java
@@ -23,10 +23,10 @@ import static org.testng.Assert.assertEquals;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -72,14 +72,14 @@ public class CouchDBClusterLiveTest {
 
         app.start(ImmutableList.of(testLocation));
 
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, CouchDBCluster.GROUP_SIZE, 2);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, CouchDBCluster.GROUP_SIZE, 2);
         Entities.dumpInfo(app);
 
         CouchDBNode first = (CouchDBNode) Iterables.get(cluster.getMembers(), 0);
         CouchDBNode second = (CouchDBNode) Iterables.get(cluster.getMembers(), 1);
 
-        EntityTestUtils.assertAttributeEqualsEventually(first, Startable.SERVICE_UP, true);
-        EntityTestUtils.assertAttributeEqualsEventually(second, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(first, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(second, Startable.SERVICE_UP, true);
 
         JcouchdbSupport jcouchdbFirst = new JcouchdbSupport(first);
         JcouchdbSupport jcouchdbSecond = new JcouchdbSupport(second);

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/couchdb/CouchDBNodeEc2LiveTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/couchdb/CouchDBNodeEc2LiveTest.java
@@ -20,9 +20,9 @@ package org.apache.brooklyn.entity.nosql.couchdb;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +40,7 @@ public class CouchDBNodeEc2LiveTest extends AbstractEc2LiveTest {
                 .configure("httpPort", "8000+"));
         app.start(ImmutableList.of(loc));
 
-        EntityTestUtils.assertAttributeEqualsEventually(couchdb, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(couchdb, Startable.SERVICE_UP, true);
 
         JcouchdbSupport jcouchdb = new JcouchdbSupport(couchdb);
         jcouchdb.jcouchdbTest();

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/couchdb/CouchDBNodeIntegrationTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/couchdb/CouchDBNodeIntegrationTest.java
@@ -19,9 +19,8 @@
 package org.apache.brooklyn.entity.nosql.couchdb;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
-import org.apache.brooklyn.entity.nosql.couchdb.CouchDBNode;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -42,11 +41,11 @@ public class CouchDBNodeIntegrationTest extends AbstractCouchDBNodeTest {
                 .configure("httpPort", "8000+"));
         app.start(ImmutableList.of(testLocation));
 
-        EntityTestUtils.assertAttributeEqualsEventually(couchdb, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(couchdb, Startable.SERVICE_UP, true);
 
         couchdb.stop();
 
-        EntityTestUtils.assertAttributeEquals(couchdb, Startable.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEquals(couchdb, Startable.SERVICE_UP, false);
     }
 
     /**
@@ -58,7 +57,7 @@ public class CouchDBNodeIntegrationTest extends AbstractCouchDBNodeTest {
                 .configure("httpPort", "8000+"));
         app.start(ImmutableList.of(testLocation));
 
-        EntityTestUtils.assertAttributeEqualsEventually(couchdb, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(couchdb, Startable.SERVICE_UP, true);
 
         JcouchdbSupport jcouchdb = new JcouchdbSupport(couchdb);
         jcouchdb.jcouchdbTest();

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/couchdb/CouchDBNodeLiveTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/couchdb/CouchDBNodeLiveTest.java
@@ -21,9 +21,8 @@ package org.apache.brooklyn.entity.nosql.couchdb;
 import java.util.Map;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
-import org.apache.brooklyn.entity.nosql.couchdb.CouchDBNode;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.text.Strings;
 import org.slf4j.Logger;
@@ -66,7 +65,7 @@ public class CouchDBNodeLiveTest extends AbstractCouchDBNodeTest {
                 .configure("httpPort", "12345+")
                 .configure("clusterName", "TestCluster"));
         app.start(ImmutableList.of(testLocation));
-        EntityTestUtils.assertAttributeEqualsEventually(couchdb, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(couchdb, Startable.SERVICE_UP, true);
 
         JcouchdbSupport jcouchdb = new JcouchdbSupport(couchdb);
         jcouchdb.jcouchdbTest();

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/mongodb/MongoDBIntegrationTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/mongodb/MongoDBIntegrationTest.java
@@ -23,10 +23,10 @@ import static org.testng.Assert.assertFalse;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -57,7 +57,7 @@ public class MongoDBIntegrationTest {
                 .configure("mongodbConfTemplateUrl", "classpath:///test-mongodb.conf"));
         app.start(ImmutableList.of(localhostProvisioningLocation));
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, true);
         entity.stop();
         assertFalse(entity.getAttribute(Startable.SERVICE_UP));
     }
@@ -78,13 +78,13 @@ public class MongoDBIntegrationTest {
         MongoDBServer entity = app.createAndManageChild(EntitySpec.create(MongoDBServer.class)
                 .configure("mongodbConfTemplateUrl", "classpath:///test-mongodb.conf"));
         app.start(ImmutableList.of(localhostProvisioningLocation));
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, true);
 
-        EntityTestUtils.assertAttributeEventuallyNonNull(entity, MongoDBServer.OPCOUNTERS_INSERTS);
+        EntityAsserts.assertAttributeEventuallyNonNull(entity, MongoDBServer.OPCOUNTERS_INSERTS);
         Long initialInserts = entity.getAttribute(MongoDBServer.OPCOUNTERS_INSERTS);
         MongoDBTestHelper.insert(entity, "a", Boolean.TRUE);
         MongoDBTestHelper.insert(entity, "b", Boolean.FALSE);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, MongoDBServer.OPCOUNTERS_INSERTS, initialInserts + 2);
+        EntityAsserts.assertAttributeEqualsEventually(entity, MongoDBServer.OPCOUNTERS_INSERTS, initialInserts + 2);
     }
 
 }

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/mongodb/MongoDBRebindIntegrationTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/mongodb/MongoDBRebindIntegrationTest.java
@@ -19,8 +19,8 @@
 package org.apache.brooklyn.entity.nosql.mongodb;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
@@ -45,15 +45,15 @@ public class MongoDBRebindIntegrationTest extends RebindTestFixtureWithApp {
         MongoDBServer origEntity = origApp.createAndManageChild(EntitySpec.create(MongoDBServer.class)
                 .configure("mongodbConfTemplateUrl", "classpath:///test-mongodb.conf"));
         origApp.start(ImmutableList.of(loc));
-        EntityTestUtils.assertAttributeEventuallyNonNull(origEntity, MongoDBServer.STATUS_BSON);
+        EntityAsserts.assertAttributeEventuallyNonNull(origEntity, MongoDBServer.STATUS_BSON);
 
         // rebind
         rebind();
         final MongoDBServer newEntity = (MongoDBServer) Iterables.find(newApp.getChildren(), Predicates.instanceOf(MongoDBServer.class));
 
         // confirm effectors still work on entity
-        EntityTestUtils.assertAttributeEqualsEventually(newEntity, MongoDBServer.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(newEntity, MongoDBServer.SERVICE_UP, true);
         newEntity.stop();
-        EntityTestUtils.assertAttributeEqualsEventually(newEntity, MongoDBServer.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(newEntity, MongoDBServer.SERVICE_UP, false);
     }
 }

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/mongodb/MongoDBSoftLayerLiveTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/mongodb/MongoDBSoftLayerLiveTest.java
@@ -22,8 +22,8 @@ import static org.testng.Assert.assertEquals;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.entity.AbstractSoftlayerLiveTest;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
@@ -42,7 +42,7 @@ public class MongoDBSoftLayerLiveTest extends AbstractSoftlayerLiveTest {
                 .configure("mongodbConfTemplateUrl", "classpath:///test-mongodb.conf"));
         app.start(ImmutableList.of(loc));
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, MongoDBServer.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(entity, MongoDBServer.SERVICE_UP, true);
 
         String id = MongoDBTestHelper.insert(entity, "hello", "world!");
         DBObject docOut = MongoDBTestHelper.getById(entity, id);

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/mongodb/MongoDBWinEc2LiveTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/mongodb/MongoDBWinEc2LiveTest.java
@@ -23,6 +23,7 @@ import org.apache.brooklyn.api.location.MachineProvisioningLocation;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.BrooklynConfigKeys;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.internal.BrooklynProperties;
@@ -32,7 +33,6 @@ import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.software.base.VanillaWindowsProcess;
 import org.apache.brooklyn.entity.software.base.test.location.WindowsTestFixture;
 import org.apache.brooklyn.location.winrm.WinRmMachineLocation;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
@@ -122,13 +122,13 @@ public class MongoDBWinEc2LiveTest {
 
         app.start(ImmutableList.of(machine));
         LOG.info("app started; asserting up");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
 
         entity.stop();
         LOG.info("stopping entity");
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Attributes.SERVICE_UP, false);
     }
 
     @Test(enabled = false)

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/mongodb/sharding/MongoDBConfigServerIntegrationTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/mongodb/sharding/MongoDBConfigServerIntegrationTest.java
@@ -22,13 +22,13 @@ import static org.testng.Assert.assertFalse;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.nosql.mongodb.MongoDBServer;
 import org.apache.brooklyn.entity.nosql.mongodb.MongoDBTestHelper;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -57,7 +57,7 @@ public class MongoDBConfigServerIntegrationTest {
                 .configure(MongoDBServer.MONGODB_CONF_TEMPLATE_URL, "classpath:///test-mongodb-configserver.conf"));
         app.start(ImmutableList.of(localhostProvisioningLocation));
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, true);
         Asserts.assertTrue(MongoDBTestHelper.isConfigServer(entity), "Server is not a config server");
         entity.stop();
         assertFalse(entity.getAttribute(Startable.SERVICE_UP));

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/mongodb/sharding/MongoDBShardedDeploymentIntegrationTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/mongodb/sharding/MongoDBShardedDeploymentIntegrationTest.java
@@ -20,13 +20,13 @@ package org.apache.brooklyn.entity.nosql.mongodb.sharding;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
 import org.apache.brooklyn.entity.nosql.mongodb.AbstractMongoDBServer;
 import org.apache.brooklyn.entity.nosql.mongodb.MongoDBReplicaSet;
 import org.apache.brooklyn.entity.nosql.mongodb.MongoDBServer;
 import org.apache.brooklyn.entity.nosql.mongodb.MongoDBTestHelper;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -63,7 +63,7 @@ public class MongoDBShardedDeploymentIntegrationTest extends BrooklynAppLiveTest
                 .configure(MongoDBShardedDeployment.MONGODB_CONFIG_SERVER_SPEC, EntitySpec.create(MongoDBConfigServer.class)
                         .configure(MongoDBConfigServer.MONGODB_CONF_TEMPLATE_URL, "classpath:///test-mongodb-configserver.conf")));
         app.start(ImmutableList.of(localhostProvisioningLocation));
-        EntityTestUtils.assertAttributeEqualsEventually(deployment, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(deployment, Startable.SERVICE_UP, true);
         return deployment;
     }
     
@@ -71,7 +71,7 @@ public class MongoDBShardedDeploymentIntegrationTest extends BrooklynAppLiveTest
     public void testCanStartAndStopDeployment() {
         MongoDBShardedDeployment deployment = makeAndStartDeployment();
         deployment.stop();
-        EntityTestUtils.assertAttributeEqualsEventually(deployment, Startable.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(deployment, Startable.SERVICE_UP, false);
     }
     
     @Test(groups = "Integration")
@@ -103,18 +103,18 @@ public class MongoDBShardedDeploymentIntegrationTest extends BrooklynAppLiveTest
     @Test(groups = "Integration")
     private void testReadAndWriteDifferentRouters() {
         MongoDBShardedDeployment deployment = makeAndStartDeployment();
-        EntityTestUtils.assertAttributeEqualsEventually(deployment, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(deployment, Startable.SERVICE_UP, true);
         MongoDBRouter router1 = (MongoDBRouter) Iterables.get(deployment.getRouterCluster().getMembers(), 0);
         MongoDBRouter router2 = (MongoDBRouter) Iterables.get(deployment.getRouterCluster().getMembers(), 1);
-        EntityTestUtils.assertAttributeEqualsEventually(router1, Startable.SERVICE_UP, true);
-        EntityTestUtils.assertAttributeEqualsEventually(router2, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(router1, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(router2, Startable.SERVICE_UP, true);
         
         String documentId = MongoDBTestHelper.insert(router1, "meaning-of-life", 42);
         DBObject docOut = MongoDBTestHelper.getById(router2, documentId);
         Assert.assertEquals(docOut.get("meaning-of-life"), 42);
         
         for (Entity entity : Iterables.filter(app.getManagementContext().getEntityManager().getEntitiesInApplication(app), AbstractMongoDBServer.class)) {
-            EntityTestUtils.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, true);
+            EntityAsserts.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, true);
         }
     }
     
@@ -122,7 +122,7 @@ public class MongoDBShardedDeploymentIntegrationTest extends BrooklynAppLiveTest
         Assert.assertNotNull(entity);
         Assert.assertTrue(expectedClass.isAssignableFrom(entity.getClass()), "expected: " + expectedClass 
                 + " on interfaces, found: " + entity.getClass().getInterfaces());
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, true);
     }
 
 }

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/redis/RedisClusterIntegrationTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/redis/RedisClusterIntegrationTest.java
@@ -27,12 +27,12 @@ import java.util.concurrent.Callable;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.group.DynamicCluster;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -66,7 +66,7 @@ public class RedisClusterIntegrationTest {
                 .configure(DynamicCluster.INITIAL_SIZE, 3));
         app.start(ImmutableList.of(loc));
 
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, Startable.SERVICE_UP, true);
 
         RedisStore master = cluster.getMaster();
         List<RedisSlave> slaves = ImmutableList.<RedisSlave>copyOf((Collection)cluster.getSlaves().getMembers());
@@ -89,7 +89,7 @@ public class RedisClusterIntegrationTest {
         // Check that stopping slave will not stop anything else
         // (it used to stop master because wasn't supplying port!)
         slaves.get(0).stop();
-        EntityTestUtils.assertAttributeEqualsEventually(slaves.get(0), Startable.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(slaves.get(0), Startable.SERVICE_UP, false);
         
         assertEquals(master.getAttribute(Startable.SERVICE_UP), Boolean.TRUE);
         for (RedisSlave slave : slaves.subList(1, slaves.size())) {
@@ -99,7 +99,7 @@ public class RedisClusterIntegrationTest {
         // Check that stopping cluster will stop everything
         cluster.stop();
 
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, Startable.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, Startable.SERVICE_UP, false);
         assertEquals(master.getAttribute(Startable.SERVICE_UP), Boolean.FALSE);
         for (RedisSlave slave : slaves) {
             assertEquals(slave.getAttribute(Startable.SERVICE_UP), Boolean.FALSE);

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/redis/RedisEc2LiveTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/redis/RedisEc2LiveTest.java
@@ -29,7 +29,6 @@ import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
@@ -47,12 +46,12 @@ public class RedisEc2LiveTest extends AbstractEc2LiveTest {
     protected void doTest(Location loc) throws Exception {
         RedisStore redis = app.createAndManageChild(EntitySpec.create(RedisStore.class));
         app.start(ImmutableList.of(loc));
-        EntityTestUtils.assertAttributeEqualsEventually(redis, RedisStore.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(redis, RedisStore.SERVICE_UP, true);
 
         JedisSupport support = new JedisSupport(redis);
         support.redisTest();
         // Confirm sensors are valid
-        EntityTestUtils.assertPredicateEventuallyTrue(redis, new Predicate<RedisStore>() {
+        EntityAsserts.assertPredicateEventuallyTrue(redis, new Predicate<RedisStore>() {
             @Override public boolean apply(@Nullable RedisStore input) {
                 return input != null &&
                         input.getAttribute(RedisStore.UPTIME) > 0 &&

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/redis/RedisIntegrationTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/redis/RedisIntegrationTest.java
@@ -23,10 +23,10 @@ import javax.annotation.Nullable;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.location.PortRanges;
 import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.time.Duration;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -64,11 +64,11 @@ public class RedisIntegrationTest {
         redis = app.createAndManageChild(EntitySpec.create(RedisStore.class));
         app.start(ImmutableList.of(loc));
 
-        EntityTestUtils.assertAttributeEqualsEventually(redis, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(redis, Startable.SERVICE_UP, true);
 
         redis.stop();
 
-        EntityTestUtils.assertAttributeEqualsEventually(redis, Startable.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(redis, Startable.SERVICE_UP, false);
     }
 
     /**
@@ -79,7 +79,7 @@ public class RedisIntegrationTest {
         redis = app.createAndManageChild(EntitySpec.create(RedisStore.class));
         app.start(ImmutableList.of(loc));
 
-        EntityTestUtils.assertAttributeEqualsEventually(redis, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(redis, Startable.SERVICE_UP, true);
 
         JedisSupport support = new JedisSupport(redis);
         support.redisTest();
@@ -94,7 +94,7 @@ public class RedisIntegrationTest {
                 .configure(RedisStore.REDIS_PORT, PortRanges.fromString("10000+")));
         app.start(ImmutableList.of(loc));
 
-        EntityTestUtils.assertAttributeEqualsEventually(redis, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(redis, Startable.SERVICE_UP, true);
         JedisSupport support = new JedisSupport(redis);
         support.redisTest();
 
@@ -102,7 +102,7 @@ public class RedisIntegrationTest {
         // call to `info server` (for obtaining uptime) which took 26 seconds; then 4 seconds later 
         // this assert failed (with it checking every 500ms). The response did correctly contain
         // `uptime_in_seconds:27`.
-        EntityTestUtils.assertPredicateEventuallyTrue(ImmutableMap.of("timeout", Duration.FIVE_MINUTES), redis, new Predicate<RedisStore>() {
+        EntityAsserts.assertPredicateEventuallyTrue(ImmutableMap.of("timeout", Duration.FIVE_MINUTES), redis, new Predicate<RedisStore>() {
             @Override public boolean apply(@Nullable RedisStore input) {
                 return input != null &&
                         input.getAttribute(RedisStore.UPTIME) > 0 &&

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/riak/RiakClusterEc2LiveTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/riak/RiakClusterEc2LiveTest.java
@@ -21,8 +21,8 @@ package org.apache.brooklyn.entity.nosql.riak;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
@@ -42,20 +42,20 @@ public class RiakClusterEc2LiveTest extends AbstractEc2LiveTest {
                 .configure(RiakCluster.MEMBER_SPEC, EntitySpec.create(RiakNode.class)));
         app.start(ImmutableList.of(loc));
 
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, RiakNode.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, RiakNode.SERVICE_UP, true);
 
         RiakNode first = (RiakNode) Iterables.get(cluster.getMembers(), 0);
         RiakNode second = (RiakNode) Iterables.get(cluster.getMembers(), 1);
 
         assertNodesUpAndInCluster(first, second);
         
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, Attributes.SERVICE_UP, true);
     }
     
     private void assertNodesUpAndInCluster(final RiakNode... nodes) {
         for (final RiakNode node : nodes) {
-            EntityTestUtils.assertAttributeEqualsEventually(node, RiakNode.SERVICE_UP, true);
-            EntityTestUtils.assertAttributeEqualsEventually(node, RiakNode.RIAK_NODE_HAS_JOINED_CLUSTER, true);
+            EntityAsserts.assertAttributeEqualsEventually(node, RiakNode.SERVICE_UP, true);
+            EntityAsserts.assertAttributeEqualsEventually(node, RiakNode.RIAK_NODE_HAS_JOINED_CLUSTER, true);
         }
     }
 

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeEc2LiveTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeEc2LiveTest.java
@@ -27,7 +27,6 @@ import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.location.cloud.CloudLocationConfig;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.annotations.Test;
@@ -45,7 +44,7 @@ public class RiakNodeEc2LiveTest extends AbstractEc2LiveTest {
         RiakNode entity = app.createAndManageChild(EntitySpec.create(RiakNode.class));
         app.start(ImmutableList.of(loc));
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, RiakNode.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(entity, RiakNode.SERVICE_UP, true);
 
     }
 

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeGoogleComputeLiveTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeGoogleComputeLiveTest.java
@@ -20,8 +20,8 @@ package org.apache.brooklyn.entity.nosql.riak;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.entity.AbstractGoogleComputeLiveTest;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -35,16 +35,16 @@ public class RiakNodeGoogleComputeLiveTest extends AbstractGoogleComputeLiveTest
                 .configure(RiakCluster.MEMBER_SPEC, EntitySpec.create(RiakNode.class)));
         app.start(ImmutableList.of(loc));
 
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, RiakCluster.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, RiakCluster.SERVICE_UP, true);
 
         RiakNode first = (RiakNode) Iterables.get(cluster.getMembers(), 0);
         RiakNode second = (RiakNode) Iterables.get(cluster.getMembers(), 1);
 
-        EntityTestUtils.assertAttributeEqualsEventually(first, RiakNode.SERVICE_UP, true);
-        EntityTestUtils.assertAttributeEqualsEventually(second, RiakNode.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(first, RiakNode.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(second, RiakNode.SERVICE_UP, true);
 
-        EntityTestUtils.assertAttributeEqualsEventually(first, RiakNode.RIAK_NODE_HAS_JOINED_CLUSTER, true);
-        EntityTestUtils.assertAttributeEqualsEventually(second, RiakNode.RIAK_NODE_HAS_JOINED_CLUSTER, true);
+        EntityAsserts.assertAttributeEqualsEventually(first, RiakNode.RIAK_NODE_HAS_JOINED_CLUSTER, true);
+        EntityAsserts.assertAttributeEqualsEventually(second, RiakNode.RIAK_NODE_HAS_JOINED_CLUSTER, true);
 
     }
 

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeIntegrationTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeIntegrationTest.java
@@ -22,9 +22,9 @@ import static org.testng.Assert.assertFalse;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -222,7 +222,7 @@ public class RiakNodeIntegrationTest {
                 .configure(RiakNode.SUGGESTED_VERSION, "2.1.1"));
         app.start(ImmutableList.of(localhostProvisioningLocation));
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, true);
         entity.stop();
         assertFalse(entity.getAttribute(Startable.SERVICE_UP));
     }

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeSoftlayerLiveTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeSoftlayerLiveTest.java
@@ -20,8 +20,8 @@ package org.apache.brooklyn.entity.nosql.riak;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.entity.AbstractSoftlayerLiveTest;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.BeforeMethod;
 
 import com.google.common.collect.ImmutableList;
@@ -39,6 +39,6 @@ public class RiakNodeSoftlayerLiveTest extends AbstractSoftlayerLiveTest {
                 .configure(RiakNode.SUGGESTED_VERSION, "2.1.1"));
         app.start(ImmutableList.of(loc));
 
-        EntityTestUtils.assertAttributeEqualsEventually(entity, RiakNode.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(entity, RiakNode.SERVICE_UP, true);
     }
 }

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/solr/SolrServerIntegrationTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/solr/SolrServerIntegrationTest.java
@@ -23,9 +23,8 @@ import static org.testng.Assert.assertTrue;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
-import org.apache.brooklyn.entity.nosql.solr.SolrServer;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.solr.common.SolrDocument;
 import org.testng.annotations.Test;
@@ -49,12 +48,12 @@ public class SolrServerIntegrationTest extends AbstractSolrServerTest {
         solr = app.createAndManageChild(EntitySpec.create(SolrServer.class));
         app.start(ImmutableList.of(testLocation));
 
-        EntityTestUtils.assertAttributeEqualsEventually(solr, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(solr, Startable.SERVICE_UP, true);
         Entities.dumpInfo(app);
 
         solr.stop();
 
-        EntityTestUtils.assertAttributeEqualsEventually(solr, Startable.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(solr, Startable.SERVICE_UP, false);
     }
 
     /**
@@ -66,7 +65,7 @@ public class SolrServerIntegrationTest extends AbstractSolrServerTest {
                 .configure(SolrServer.SOLR_CORE_CONFIG, ImmutableMap.of("example", "classpath://solr/example.tgz")));
         app.start(ImmutableList.of(testLocation));
 
-        EntityTestUtils.assertAttributeEqualsEventually(solr, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(solr, Startable.SERVICE_UP, true);
 
         SolrJSupport client = new SolrJSupport(solr, "example");
 

--- a/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/solr/SolrServerLiveTest.java
+++ b/software/nosql/src/test/java/org/apache/brooklyn/entity/nosql/solr/SolrServerLiveTest.java
@@ -24,9 +24,8 @@ import static org.testng.Assert.assertTrue;
 import java.util.Map;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
-import org.apache.brooklyn.entity.nosql.solr.SolrServer;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.solr.common.SolrDocument;
@@ -71,7 +70,7 @@ public class SolrServerLiveTest extends AbstractSolrServerTest {
                 .configure(SolrServer.SOLR_CORE_CONFIG, ImmutableMap.of("example", "classpath://solr/example.tgz")));
         app.start(ImmutableList.of(testLocation));
 
-        EntityTestUtils.assertAttributeEqualsEventually(solr, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(solr, Startable.SERVICE_UP, true);
 
         SolrJSupport client = new SolrJSupport(solr, "example");
 

--- a/software/osgi/src/test/java/org/apache/brooklyn/entity/osgi/karaf/KarafContainerEc2LiveTest.java
+++ b/software/osgi/src/test/java/org/apache/brooklyn/entity/osgi/karaf/KarafContainerEc2LiveTest.java
@@ -20,8 +20,8 @@ package org.apache.brooklyn.entity.osgi.karaf;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.util.text.Identifiers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,7 +44,7 @@ public class KarafContainerEc2LiveTest extends AbstractEc2LiveTest {
         
         app.start(ImmutableList.of(loc));
 
-        EntityTestUtils.assertAttributeEqualsEventually(karaf, KarafContainer.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(karaf, KarafContainer.SERVICE_UP, true);
     }
     
     @Test(enabled=false)

--- a/software/osgi/src/test/java/org/apache/brooklyn/entity/osgi/karaf/KarafContainerTest.java
+++ b/software/osgi/src/test/java/org/apache/brooklyn/entity/osgi/karaf/KarafContainerTest.java
@@ -29,9 +29,9 @@ import org.apache.brooklyn.api.location.NoMachinesAvailableException;
 import org.apache.brooklyn.core.effector.ssh.SshEffectorTasks;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.brooklyn.util.text.Identifiers;
@@ -64,14 +64,14 @@ public class KarafContainerTest extends BrooklynAppLiveTestSupport {
                 .configure("displayName", "Karaf Test"));
         
         app.start(ImmutableList.of(localhost));
-        EntityTestUtils.assertAttributeEqualsEventually(karaf, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(karaf, Attributes.SERVICE_UP, true);
         
         Entities.dumpInfo(karaf);
         final int pid = karaf.getAttribute(KarafContainer.KARAF_PID);
         Entities.submit(app, SshEffectorTasks.requirePidRunning(pid).machine(localhost.obtain())).get();
         
         karaf.stop();
-        EntityTestUtils.assertAttributeEqualsEventually(karaf, Attributes.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(karaf, Attributes.SERVICE_UP, false);
         
         Asserts.succeedsEventually(new Runnable() {
             public void run() {
@@ -92,10 +92,10 @@ public class KarafContainerTest extends BrooklynAppLiveTestSupport {
                 .configure("jmxPort", "9099+"));
         
         app.start(ImmutableList.of(localhost));
-        EntityTestUtils.assertAttributeEqualsEventually(karaf, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(karaf, Attributes.SERVICE_UP, true);
         
         karaf.stop();
-        EntityTestUtils.assertAttributeEqualsEventually(karaf, Attributes.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(karaf, Attributes.SERVICE_UP, false);
     }
     
     @Test(groups = {"Integration", "WIP"})
@@ -108,10 +108,10 @@ public class KarafContainerTest extends BrooklynAppLiveTestSupport {
             // NB: now the above parameters have the opposite semantics to before
         
         app.start(ImmutableList.of(localhost));
-        EntityTestUtils.assertAttributeEqualsEventually(karaf, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(karaf, Attributes.SERVICE_UP, true);
         
         karaf.stop();
-        EntityTestUtils.assertAttributeEqualsEventually(karaf, Attributes.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(karaf, Attributes.SERVICE_UP, false);
     }
     
     // FIXME Test failing in jenkins; not sure why. The karaf log shows the mbeans never being

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/proxy/nginx/NginxClusterIntegrationTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/proxy/nginx/NginxClusterIntegrationTest.java
@@ -28,7 +28,7 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.entity.Group;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.mgmt.EntityManager;
-import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.location.PortRanges;
 import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
@@ -38,7 +38,6 @@ import org.apache.brooklyn.entity.proxy.LoadBalancerCluster;
 import org.apache.brooklyn.entity.webapp.JavaWebAppService;
 import org.apache.brooklyn.entity.webapp.jboss.JBoss7Server;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.test.HttpTestUtils;
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -163,13 +162,13 @@ public class NginxClusterIntegrationTest extends BrooklynAppLiveTestSupport {
                 .configure(NginxController.DOMAIN_NAME, "localhost"));
         
         app.start(ImmutableList.of(localhostProvisioningLoc));
-        EntityTestUtils.assertAttributeEqualsContinually(loadBalancerCluster, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsContinually(loadBalancerCluster, Startable.SERVICE_UP, true);
         
         loadBalancerCluster.resize(0);
-        EntityTestUtils.assertAttributeEqualsEventually(loadBalancerCluster, Startable.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(loadBalancerCluster, Startable.SERVICE_UP, false);
         
         loadBalancerCluster.resize(1);
-        EntityTestUtils.assertAttributeEqualsEventually(loadBalancerCluster, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(loadBalancerCluster, Startable.SERVICE_UP, true);
     }
     
     // Warning: test is a little brittle for if a previous run leaves something on these required ports

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/proxy/nginx/NginxEc2LiveTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/proxy/nginx/NginxEc2LiveTest.java
@@ -20,10 +20,10 @@ package org.apache.brooklyn.entity.proxy.nginx;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.entity.AbstractEc2LiveTest;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.entity.webapp.WebAppService;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.test.HttpTestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -62,7 +62,7 @@ public class NginxEc2LiveTest extends AbstractEc2LiveTest {
         app.start(ImmutableList.of(loc));
 
         // nginx should be up, and URL reachable
-        EntityTestUtils.assertAttributeEqualsEventually(nginx, SoftwareProcess.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(nginx, SoftwareProcess.SERVICE_UP, true);
         HttpTestUtils.assertHttpStatusCodeEventuallyEquals(nginx.getAttribute(NginxController.ROOT_URL), 404);
     }
     

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/proxy/nginx/NginxIntegrationTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/proxy/nginx/NginxIntegrationTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.brooklyn.entity.proxy.nginx;
 
-import static org.apache.brooklyn.test.EntityTestUtils.assertAttributeEqualsEventually;
 import static org.apache.brooklyn.test.HttpTestUtils.assertHttpStatusCodeEquals;
 import static org.apache.brooklyn.test.HttpTestUtils.assertHttpStatusCodeEventuallyEquals;
 import static org.testng.Assert.assertFalse;
@@ -30,6 +29,7 @@ import java.util.Map;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.factory.EntityFactory;
 import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
 import org.apache.brooklyn.entity.group.DynamicCluster;
@@ -89,8 +89,8 @@ public class NginxIntegrationTest extends BrooklynAppLiveTestSupport {
                 .configure("domain", "localhost"));
         
         app.start(ImmutableList.of(localLoc));
-        
-        assertAttributeEqualsEventually(nginx, SoftwareProcess.SERVICE_UP, true);
+
+        EntityAsserts.assertAttributeEqualsEventually(nginx, SoftwareProcess.SERVICE_UP, true);
         assertHttpStatusCodeEventuallyEquals(nginx.getAttribute(NginxController.ROOT_URL), 404);
     }
 
@@ -110,8 +110,8 @@ public class NginxIntegrationTest extends BrooklynAppLiveTestSupport {
         app.start(ImmutableList.of(localLoc));
 
         nginx.restart();
-        
-        assertAttributeEqualsEventually(nginx, SoftwareProcess.SERVICE_UP, true);
+
+        EntityAsserts.assertAttributeEqualsEventually(nginx, SoftwareProcess.SERVICE_UP, true);
         assertHttpStatusCodeEventuallyEquals(nginx.getAttribute(NginxController.ROOT_URL), 404);
     }
 
@@ -218,11 +218,11 @@ public class NginxIntegrationTest extends BrooklynAppLiveTestSupport {
         app.start(ImmutableList.of(localLoc));
         
         // App-servers and nginx has started
-        assertAttributeEqualsEventually(serverPool, SoftwareProcess.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(serverPool, SoftwareProcess.SERVICE_UP, true);
         for (Entity member : serverPool.getMembers()) {
-            assertAttributeEqualsEventually(member, SoftwareProcess.SERVICE_UP, true);
+            EntityAsserts.assertAttributeEqualsEventually(member, SoftwareProcess.SERVICE_UP, true);
         }
-        assertAttributeEqualsEventually(nginx, SoftwareProcess.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(nginx, SoftwareProcess.SERVICE_UP, true);
 
         // URLs reachable
         assertHttpStatusCodeEventuallyEquals(nginx.getAttribute(NginxController.ROOT_URL), 200);
@@ -269,8 +269,8 @@ public class NginxIntegrationTest extends BrooklynAppLiveTestSupport {
         assertNotEquals(url1, url2, "Two nginxs should listen on different ports, not both on "+url1);
         
         // Nginx has started
-        assertAttributeEqualsEventually(nginx1, SoftwareProcess.SERVICE_UP, true);
-        assertAttributeEqualsEventually(nginx2, SoftwareProcess.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(nginx1, SoftwareProcess.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(nginx2, SoftwareProcess.SERVICE_UP, true);
 
         // Nginx reachable (returning default 404)
         assertHttpStatusCodeEventuallyEquals(url1, 404);

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/proxy/nginx/NginxRebindIntegrationTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/proxy/nginx/NginxRebindIntegrationTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.brooklyn.entity.proxy.nginx;
 
-import static org.apache.brooklyn.test.EntityTestUtils.assertAttributeEqualsEventually;
 import static org.apache.brooklyn.test.HttpTestUtils.assertHttpStatusCodeEquals;
 import static org.apache.brooklyn.test.HttpTestUtils.assertHttpStatusCodeEventuallyEquals;
 import static org.testng.Assert.assertEquals;
@@ -34,6 +33,7 @@ import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.entity.Group;
 import org.apache.brooklyn.api.location.LocationSpec;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.lifecycle.Lifecycle;
 import org.apache.brooklyn.core.mgmt.rebind.RebindOptions;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
@@ -45,7 +45,6 @@ import org.apache.brooklyn.entity.proxy.nginx.UrlRewriteRule;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.entity.webapp.tomcat.Tomcat8Server;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.test.WebAppMonitor;
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
 import org.slf4j.Logger;
@@ -140,14 +139,14 @@ public class NginxRebindIntegrationTest extends RebindTestFixtureWithApp {
         final NginxController newNginx = (NginxController) Iterables.find(newApp.getChildren(), Predicates.instanceOf(NginxController.class));
 
         assertEquals(newNginx.getConfigFile(), origConfigFile);
-        
-        EntityTestUtils.assertAttributeEqualsEventually(newNginx, NginxController.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
+
+        EntityAsserts.assertAttributeEqualsEventually(newNginx, NginxController.SERVICE_STATE_ACTUAL, Lifecycle.RUNNING);
         assertEquals(newNginx.getAttribute(NginxController.PROXY_HTTP_PORT), (Integer)nginxPort);
         assertEquals(newNginx.getAttribute(NginxController.ROOT_URL), rootUrl);
         assertEquals(newNginx.getAttribute(NginxController.PROXY_HTTP_PORT), origNginx.getAttribute(NginxController.PROXY_HTTP_PORT));
         assertEquals(newNginx.getConfig(NginxController.STICKY), origNginx.getConfig(NginxController.STICKY));
-        
-        assertAttributeEqualsEventually(newNginx, SoftwareProcess.SERVICE_UP, true);
+
+        EntityAsserts.assertAttributeEqualsEventually(newNginx, SoftwareProcess.SERVICE_UP, true);
         assertHttpStatusCodeEventuallyEquals(rootUrl, 404);
         
         assertEquals(monitor.getFailures(), 0);
@@ -231,9 +230,9 @@ public class NginxRebindIntegrationTest extends RebindTestFixtureWithApp {
                 Map<Entity, String> newNginxMemebers = newNginx.getAttribute(NginxController.SERVER_POOL_TARGETS);
                 assertEquals(newNginxMemebers.keySet(), ImmutableSet.of(newServer));
             }});
-        
-        
-        assertAttributeEqualsEventually(newNginx, SoftwareProcess.SERVICE_UP, true);
+
+
+        EntityAsserts.assertAttributeEqualsEventually(newNginx, SoftwareProcess.SERVICE_UP, true);
         assertHttpStatusCodeEventuallyEquals(rootUrl, 200);
 
         assertEquals(newNginx.getConfigFile(), origConfigFile);
@@ -338,8 +337,8 @@ public class NginxRebindIntegrationTest extends RebindTestFixtureWithApp {
         final NginxController newNginx = (NginxController) Iterables.find(newApp.getChildren(), Predicates.instanceOf(NginxController.class));
         DynamicCluster newServerPool = (DynamicCluster) newManagementContext.getEntityManager().getEntity(origServerPool.getId());
         Tomcat8Server newServer = (Tomcat8Server) Iterables.getOnlyElement(newServerPool.getMembers());
-        
-        assertAttributeEqualsEventually(newNginx, SoftwareProcess.SERVICE_UP, true);
+
+        EntityAsserts.assertAttributeEqualsEventually(newNginx, SoftwareProcess.SERVICE_UP, true);
         assertHttpStatusCodeEventuallyEquals(mappingGroupUrl, 200);
         
         assertEquals(newNginx.getConfigFile(), origConfigFile);

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/AbstractWebAppFixtureIntegrationTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/AbstractWebAppFixtureIntegrationTest.java
@@ -58,7 +58,6 @@ import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.test.HttpTestUtils;
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
 import org.apache.brooklyn.util.collections.MutableMap;

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/ControlledDynamicWebAppClusterIntegrationTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/ControlledDynamicWebAppClusterIntegrationTest.java
@@ -24,8 +24,8 @@ import static org.testng.Assert.assertNotNull;
 import java.util.List;
 import java.util.concurrent.Callable;
 
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.test.HttpTestUtils;
 import org.apache.brooklyn.test.entity.TestJavaWebAppEntity;
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
@@ -78,8 +78,8 @@ public class ControlledDynamicWebAppClusterIntegrationTest extends BrooklynAppLi
                 .configure("initialSize", 1));
         app.start(locs);
 
-        EntityTestUtils.assertAttributeEventuallyNonNull(cluster, LoadBalancer.PROXY_HTTP_PORT);
-        EntityTestUtils.assertAttributeEventuallyNonNull(cluster, LoadBalancer.PROXY_HTTPS_PORT);
+        EntityAsserts.assertAttributeEventuallyNonNull(cluster, LoadBalancer.PROXY_HTTP_PORT);
+        EntityAsserts.assertAttributeEventuallyNonNull(cluster, LoadBalancer.PROXY_HTTPS_PORT);
     }
     
     @Test(groups="Integration")
@@ -108,9 +108,9 @@ public class ControlledDynamicWebAppClusterIntegrationTest extends BrooklynAppLi
         assertNotNull(expectedHostname);
         assertNotNull(expectedRootUrl);
         
-        EntityTestUtils.assertAttributeEqualsEventually(MutableMap.of("timeout", TIMEOUT_MS), cluster, ControlledDynamicWebAppCluster.HOSTNAME, expectedHostname);
-        EntityTestUtils.assertAttributeEqualsEventually(MutableMap.of("timeout", TIMEOUT_MS), cluster, ControlledDynamicWebAppCluster.ROOT_URL, expectedRootUrl);
-        EntityTestUtils.assertAttributeEqualsEventually(MutableMap.of("timeout", TIMEOUT_MS), cluster, ControlledDynamicWebAppCluster.SERVICE_UP, expectedServiceUp);
+        EntityAsserts.assertAttributeEqualsEventually(MutableMap.of("timeout", TIMEOUT_MS), cluster, ControlledDynamicWebAppCluster.HOSTNAME, expectedHostname);
+        EntityAsserts.assertAttributeEqualsEventually(MutableMap.of("timeout", TIMEOUT_MS), cluster, ControlledDynamicWebAppCluster.ROOT_URL, expectedRootUrl);
+        EntityAsserts.assertAttributeEqualsEventually(MutableMap.of("timeout", TIMEOUT_MS), cluster, ControlledDynamicWebAppCluster.SERVICE_UP, expectedServiceUp);
     }
     
     @Test(groups="Integration")
@@ -137,7 +137,7 @@ public class ControlledDynamicWebAppClusterIntegrationTest extends BrooklynAppLi
                 .configure("initialSize", 1)
                 .configure(ControlledDynamicWebAppCluster.MEMBER_SPEC, EntitySpec.create(TestJavaWebAppEntity.class)) );
         
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
         
         RecordingSensorEventListener<Lifecycle> listener = new RecordingSensorEventListener<Lifecycle>(true);
         app.subscriptions().subscribe(cluster, Attributes.SERVICE_STATE_ACTUAL, listener);
@@ -148,7 +148,7 @@ public class ControlledDynamicWebAppClusterIntegrationTest extends BrooklynAppLi
         listener.clearEvents();
         
         app.stop();
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, Attributes.SERVICE_STATE_ACTUAL, Lifecycle.STOPPED);
         Asserts.eventually(Suppliers.ofInstance(listener), CollectionFunctionals.sizeEquals(2));
         assertEquals(listener.getEventValues(), ImmutableList.of(Lifecycle.STOPPING, Lifecycle.STOPPED), "vals="+listener.getEventValues());
     }
@@ -172,9 +172,9 @@ public class ControlledDynamicWebAppClusterIntegrationTest extends BrooklynAppLi
         });
         
         Entity tomcatServer = Iterables.getOnlyElement(cluster.getCluster().getMembers());
-        EntityTestUtils.assertAttributeEqualsEventually(tomcatServer, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(tomcatServer, Attributes.SERVICE_UP, true);
         
-        EntityTestUtils.assertAttributeEqualsContinually(nginxController, Attributes.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsContinually(nginxController, Attributes.SERVICE_UP, true);
         
         app.stop();
     }

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/DynamicWebAppClusterTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/DynamicWebAppClusterTest.java
@@ -25,10 +25,10 @@ import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.location.SimulatedLocation;
 import org.apache.brooklyn.core.test.entity.TestApplication;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.test.entity.TestJavaWebAppEntity;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.testng.annotations.AfterMethod;
@@ -61,8 +61,8 @@ public class DynamicWebAppClusterTest {
     public void testTestJavaWebAppEntityStarts() throws Exception {
         Entity test = app.createAndManageChild(EntitySpec.create(TestJavaWebAppEntity.class));
         test.invoke(Startable.START, ImmutableMap.of("locations", ImmutableList.of(loc))).get();
-        
-        EntityTestUtils.assertAttributeEqualsEventually(test, Attributes.SERVICE_UP, true);
+
+        EntityAsserts.assertAttributeEqualsEventually(test, Attributes.SERVICE_UP, true);
     }
     
     @Test
@@ -76,14 +76,14 @@ public class DynamicWebAppClusterTest {
         for (Entity member : cluster.getMembers()) {
             ((TestJavaWebAppEntity)member).spoofRequest();
         }
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, DynamicWebAppCluster.REQUEST_COUNT, 2);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, DynamicWebAppCluster.REQUEST_COUNT, 2);
         
         for (Entity member : cluster.getMembers()) {
             for (int i = 0; i < 2; i++) {
                 ((TestJavaWebAppEntity)member).spoofRequest();
             }
         }
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, DynamicWebAppCluster.REQUEST_COUNT_PER_NODE, 3d);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, DynamicWebAppCluster.REQUEST_COUNT_PER_NODE, 3d);
     }
     
     @Test
@@ -95,23 +95,23 @@ public class DynamicWebAppClusterTest {
         app.start(ImmutableList.of(loc));
         
         // Should initially be true (now that TestJavaWebAppEntity sets true) 
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, DynamicWebAppCluster.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, DynamicWebAppCluster.SERVICE_UP, true);
         
         // When child is !service_up, should report false
         ((EntityLocal)Iterables.get(cluster.getMembers(), 0)).sensors().set(Startable.SERVICE_UP, false);
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, DynamicWebAppCluster.SERVICE_UP, false);
-        EntityTestUtils.assertAttributeEqualsContinually(MutableMap.of("timeout", SHORT_WAIT_MS), cluster, DynamicWebAppCluster.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, DynamicWebAppCluster.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsContinually(MutableMap.of("timeout", SHORT_WAIT_MS), cluster, DynamicWebAppCluster.SERVICE_UP, false);
         
         cluster.resize(2);
         
         // When one of the two children is service_up, should report true
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, DynamicWebAppCluster.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, DynamicWebAppCluster.SERVICE_UP, true);
 
         // And if that serviceUp child goes away, should again report false
         Entities.unmanage(Iterables.get(cluster.getMembers(), 1));
         ((EntityLocal)Iterables.get(cluster.getMembers(), 0)).sensors().set(Startable.SERVICE_UP, false);
         
-        EntityTestUtils.assertAttributeEqualsEventually(cluster, DynamicWebAppCluster.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(cluster, DynamicWebAppCluster.SERVICE_UP, false);
     }
     
     @Test

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/DynamicWebAppFabricTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/DynamicWebAppFabricTest.java
@@ -24,12 +24,12 @@ import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntityLocal;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.core.entity.trait.Changeable;
 import org.apache.brooklyn.core.location.SimulatedLocation;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.group.DynamicGroup;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.test.entity.TestJavaWebAppEntity;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.slf4j.Logger;
@@ -80,7 +80,7 @@ public class DynamicWebAppFabricTest {
             ((EntityInternal)member).sensors().set(DynamicGroup.GROUP_SIZE, 1);
             ((TestJavaWebAppEntity)member).spoofRequest();
         }
-        EntityTestUtils.assertAttributeEqualsEventually(MutableMap.of("timeout", TIMEOUT_MS), fabric, DynamicWebAppFabric.REQUEST_COUNT, 2);
+        EntityAsserts.assertAttributeEqualsEventually(MutableMap.of("timeout", TIMEOUT_MS), fabric, DynamicWebAppFabric.REQUEST_COUNT, 2);
         
         // Note this is time-sensitive: need to do the next two sends before the previous one has dropped out
         // of the time-window.
@@ -89,7 +89,7 @@ public class DynamicWebAppFabricTest {
                 ((TestJavaWebAppEntity)member).spoofRequest();
             }
         }
-        EntityTestUtils.assertAttributeEqualsEventually(MutableMap.of("timeout", TIMEOUT_MS), fabric, DynamicWebAppFabric.REQUEST_COUNT_PER_NODE, 3d);
+        EntityAsserts.assertAttributeEqualsEventually(MutableMap.of("timeout", TIMEOUT_MS), fabric, DynamicWebAppFabric.REQUEST_COUNT_PER_NODE, 3d);
     }
     
     @Test
@@ -107,7 +107,7 @@ public class DynamicWebAppFabricTest {
                 ((TestJavaWebAppEntity)node).spoofRequest();
             }
         }
-        EntityTestUtils.assertAttributeEqualsEventually(MutableMap.of("timeout", TIMEOUT_MS), fabric, DynamicWebAppFabric.REQUEST_COUNT, 4);
+        EntityAsserts.assertAttributeEqualsEventually(MutableMap.of("timeout", TIMEOUT_MS), fabric, DynamicWebAppFabric.REQUEST_COUNT, 4);
         
         // Note this is time-sensitive: need to do the next two sends before the previous one has dropped out
         // of the time-window.
@@ -118,6 +118,6 @@ public class DynamicWebAppFabricTest {
                 }
             }
         }
-        EntityTestUtils.assertAttributeEqualsEventually(MutableMap.of("timeout", TIMEOUT_MS), fabric, DynamicWebAppFabric.REQUEST_COUNT_PER_NODE, 3d);
+        EntityAsserts.assertAttributeEqualsEventually(MutableMap.of("timeout", TIMEOUT_MS), fabric, DynamicWebAppFabric.REQUEST_COUNT_PER_NODE, 3d);
     }
 }

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/WebAppConcurrentDeployTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/WebAppConcurrentDeployTest.java
@@ -23,6 +23,7 @@ import static org.testng.Assert.assertEquals;
 import java.net.URI;
 import java.util.Collection;
 
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.http.client.HttpClient;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -38,7 +39,6 @@ import org.apache.brooklyn.core.test.BrooklynAppUnitTestSupport;
 import org.apache.brooklyn.entity.webapp.jboss.JBoss7Server;
 import org.apache.brooklyn.entity.webapp.tomcat.TomcatServer;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
 import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
@@ -74,7 +74,7 @@ public class WebAppConcurrentDeployTest extends BrooklynAppUnitTestSupport {
     public void testConcurrentDeploys(EntitySpec<? extends JavaWebAppSoftwareProcess> webServerSpec) throws Exception {
         JavaWebAppSoftwareProcess server = app.createAndManageChild(webServerSpec);
         app.start(ImmutableList.of(loc));
-        EntityTestUtils.assertAttributeEqualsEventually(server, Attributes.SERVICE_UP, Boolean.TRUE);
+        EntityAsserts.assertAttributeEqualsEventually(server, Attributes.SERVICE_UP, Boolean.TRUE);
         Collection<Task<Void>> deploys = MutableList.of();
         for (int i = 0; i < 5; i++) {
             deploys.add(server.invoke(TomcatServer.DEPLOY, MutableMap.of("url", getTestWar(), "targetName", "/")));

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/jboss/ControlledDynamicWebAppClusterRebindIntegrationTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/jboss/ControlledDynamicWebAppClusterRebindIntegrationTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.brooklyn.entity.webapp.jboss;
 
-import static org.apache.brooklyn.test.EntityTestUtils.assertAttributeEqualsEventually;
 import static org.apache.brooklyn.test.HttpTestUtils.assertHttpStatusCodeEquals;
 import static org.apache.brooklyn.test.HttpTestUtils.assertHttpStatusCodeEventuallyEquals;
 import static org.testng.Assert.assertEquals;
@@ -32,6 +31,7 @@ import java.util.concurrent.Executors;
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.factory.ApplicationBuilder;
 import org.apache.brooklyn.core.mgmt.internal.LocalManagementContext;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestUtils;
@@ -171,7 +171,7 @@ public class ControlledDynamicWebAppClusterRebindIntegrationTest {
         NginxController newNginx = (NginxController) Iterables.find(newApp.getChildren(), Predicates.instanceOf(NginxController.class));
         ControlledDynamicWebAppCluster newCluster = (ControlledDynamicWebAppCluster) Iterables.find(newApp.getChildren(), Predicates.instanceOf(ControlledDynamicWebAppCluster.class));
 
-        assertAttributeEqualsEventually(newNginx, SoftwareProcess.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(newNginx, SoftwareProcess.SERVICE_UP, true);
         assertHttpStatusCodeEquals(rootUrl, 200);
 
         // Confirm the cluster is usable: we can scale-up

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7ServerRebindingIntegrationTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7ServerRebindingIntegrationTest.java
@@ -26,11 +26,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.mgmt.rebind.RebindOptions;
 import org.apache.brooklyn.core.mgmt.rebind.RebindTestFixtureWithApp;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.test.HttpTestUtils;
 import org.apache.brooklyn.test.WebAppMonitor;
 import org.apache.brooklyn.test.support.TestResourceUnavailableException;
@@ -105,7 +105,7 @@ public class JBoss7ServerRebindingIntegrationTest extends RebindTestFixtureWithA
         assertEquals(newServer.getAttribute(JBoss7Server.MANAGEMENT_HTTP_PORT), origServer.getAttribute(JBoss7Server.MANAGEMENT_HTTP_PORT));
         assertEquals(newServer.getAttribute(JBoss7Server.DEPLOYED_WARS), origServer.getAttribute(JBoss7Server.DEPLOYED_WARS));
         
-        EntityTestUtils.assertAttributeEqualsEventually(newServer, SoftwareProcess.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(newServer, SoftwareProcess.SERVICE_UP, true);
         HttpTestUtils.assertHttpStatusCodeEventuallyEquals(newRootUrl, 200);
 
         // confirm that deploy() effector affects the correct jboss server 
@@ -114,10 +114,10 @@ public class JBoss7ServerRebindingIntegrationTest extends RebindTestFixtureWithA
         
         // check we see evidence of the enrichers and sensor-feeds having an effect.
         // Relying on WebAppMonitor to cause these to change.
-        EntityTestUtils.assertAttributeChangesEventually(newServer, JBoss7Server.REQUEST_COUNT);
-        EntityTestUtils.assertAttributeChangesEventually(newServer, JBoss7Server.REQUESTS_PER_SECOND_IN_WINDOW);
-        EntityTestUtils.assertAttributeChangesEventually(newServer, JBoss7Server.REQUESTS_PER_SECOND_IN_WINDOW);
-        EntityTestUtils.assertAttributeChangesEventually(newServer, JBoss7Server.PROCESSING_TIME_FRACTION_IN_WINDOW);
+        EntityAsserts.assertAttributeChangesEventually(newServer, JBoss7Server.REQUEST_COUNT);
+        EntityAsserts.assertAttributeChangesEventually(newServer, JBoss7Server.REQUESTS_PER_SECOND_IN_WINDOW);
+        EntityAsserts.assertAttributeChangesEventually(newServer, JBoss7Server.REQUESTS_PER_SECOND_IN_WINDOW);
+        EntityAsserts.assertAttributeChangesEventually(newServer, JBoss7Server.PROCESSING_TIME_FRACTION_IN_WINDOW);
         
         assertEquals(monitor.getFailures(), 0);
     }

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/nodejs/NodeJsWebAppFixtureIntegrationTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/nodejs/NodeJsWebAppFixtureIntegrationTest.java
@@ -26,14 +26,13 @@ import org.apache.brooklyn.api.entity.drivers.DriverDependentEntity;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.mgmt.ManagementContext;
 import org.apache.brooklyn.core.entity.Entities;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.entity.trait.Startable;
 import org.apache.brooklyn.core.location.PortRanges;
 import org.apache.brooklyn.core.test.entity.TestApplication;
 import org.apache.brooklyn.entity.software.base.SoftwareProcessDriver;
 import org.apache.brooklyn.entity.webapp.WebAppService;
-import org.apache.brooklyn.entity.webapp.nodejs.NodeJsWebAppService;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.apache.brooklyn.test.HttpTestUtils;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.net.Urls;
@@ -135,13 +134,13 @@ public class NodeJsWebAppFixtureIntegrationTest {
         LOG.info("test=testReportsServiceDownWithKilled; entity="+entity+"; app="+entity.getApplication());
         
         Entities.start(entity.getApplication(), ImmutableList.of(loc));
-        EntityTestUtils.assertAttributeEqualsEventually(MutableMap.of("timeout", Duration.minutes(2)), entity, Startable.SERVICE_UP, true);
+        EntityAsserts.assertAttributeEqualsEventually(MutableMap.of("timeout", Duration.minutes(2)), entity, Startable.SERVICE_UP, true);
 
         // Stop the underlying entity, but without our entity instance being told!
         killEntityBehindBack(entity);
         LOG.info("Killed {} behind mgmt's back, waiting for service up false in mgmt context", entity);
         
-        EntityTestUtils.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, false);
+        EntityAsserts.assertAttributeEqualsEventually(entity, Startable.SERVICE_UP, false);
         
         LOG.info("success getting service up false in primary mgmt universe");
     }

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/tomcat/TomcatServerDisableRetrieveUsageMetricsIntegrationTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/webapp/tomcat/TomcatServerDisableRetrieveUsageMetricsIntegrationTest.java
@@ -22,10 +22,10 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
+import org.apache.brooklyn.core.entity.EntityAsserts;
 import org.apache.brooklyn.core.test.BrooklynAppLiveTestSupport;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.test.Asserts;
-import org.apache.brooklyn.test.EntityTestUtils;
 import org.testng.annotations.Test;
 import org.apache.brooklyn.location.localhost.LocalhostMachineProvisioningLocation;
 
@@ -56,8 +56,8 @@ public class TomcatServerDisableRetrieveUsageMetricsIntegrationTest extends Broo
             }});
 
         // tc1 should have status info, but not usage metrics
-        EntityTestUtils.assertAttributeEventuallyNonNull(tc1, TomcatServer.CONNECTOR_STATUS);
-        EntityTestUtils.assertAttributeEqualsContinually(tc1, TomcatServer.ERROR_COUNT, null);
+        EntityAsserts.assertAttributeEventuallyNonNull(tc1, TomcatServer.CONNECTOR_STATUS);
+        EntityAsserts.assertAttributeEqualsContinually(tc1, TomcatServer.ERROR_COUNT, null);
         assertNull(tc1.getAttribute(TomcatServer.REQUEST_COUNT));
         assertNull(tc1.getAttribute(TomcatServer.TOTAL_PROCESSING_TIME));
     }


### PR DESCRIPTION
Updating deprecated EntityTestUtils methods to EntityAsserts. 
This PR follows the https://github.com/apache/brooklyn-server/pull/138