### PR TITLE
Fix BROOKLYN-271: Avoiding object hashcode in entities' toString

### DIFF
--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/proxy/nginx/NginxDefaultConfigGenerator.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/proxy/nginx/NginxDefaultConfigGenerator.java
@@ -254,4 +254,9 @@ public class NginxDefaultConfigGenerator implements NginxConfigFileGenerator {
         return true;
     }
 
+    @Override
+    public String toString(){
+        return getClass().getName();
+    }
+
 }


### PR DESCRIPTION
Fixing [BROOKLYN-271](https://issues.apache.org/jira/browse/BROOKLYN-271)
Avoiding object references in catalog ConfigKey cards. Then, `toString` method of `NginxDefaultConfigGenerator` has to return just the class name.