### PR TITLE
RiakNode Internal Networking

### DIFF
--- a/software/nosql/pom.xml
+++ b/software/nosql/pom.xml
@@ -82,6 +82,11 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.brooklyn</groupId>
+            <artifactId>brooklyn-locations-jclouds</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>
@@ -219,13 +224,6 @@
             <artifactId>brooklyn-software-base</artifactId>
             <version>${project.version}</version>
             <classifier>tests</classifier>
-            <scope>test</scope>
-        </dependency>
-        <!-- bring in jclouds for testing -->
-        <dependency>
-            <groupId>org.apache.brooklyn</groupId>
-            <artifactId>brooklyn-locations-jclouds</artifactId>
-            <version>${project.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/riak/RiakNode.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/riak/RiakNode.java
@@ -21,9 +21,11 @@ package org.apache.brooklyn.entity.nosql.riak;
 import java.net.URI;
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.reflect.TypeToken;
+
 import org.apache.brooklyn.api.catalog.Catalog;
 import org.apache.brooklyn.api.entity.ImplementedBy;
-import org.apache.brooklyn.api.location.PortRange;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.annotation.Effector;
@@ -31,16 +33,12 @@ import org.apache.brooklyn.core.annotation.EffectorParam;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.effector.MethodEffector;
 import org.apache.brooklyn.core.entity.Attributes;
-import org.apache.brooklyn.core.location.PortRanges;
 import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.PortAttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.entity.java.UsesJava;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
-
-import com.google.common.collect.ImmutableList;
-import com.google.common.reflect.TypeToken;
 
 @Catalog(name="Riak Node", description="Riak is a distributed NoSQL key-value data store that offers "
         + "extremely high availability, fault tolerance, operational simplicity and scalability.")
@@ -133,25 +131,16 @@ public interface RiakNode extends SoftwareProcess, UsesJava {
      */
 
     @SetFromFlag("handoffListenerPort")
-    ConfigKey<Integer> HANDOFF_LISTENER_PORT = ConfigKeys.newIntegerConfigKey("riak.handoff.port.internal", "Handoff Listener Port", 8099);
+    ConfigKey<Integer> HANDOFF_LISTENER_PORT = ConfigKeys.newIntegerConfigKey("riak.handoff.port", "Handoff Listener Port", 8099);
 
     @SetFromFlag("epmdListenerPort")
-    ConfigKey<Integer> EPMD_LISTENER_PORT = ConfigKeys.newIntegerConfigKey("riak.epmd.port.internal", "Erlang Port Mapper Daemon Listener Port", 4369);
+    ConfigKey<Integer> EPMD_LISTENER_PORT = ConfigKeys.newIntegerConfigKey("riak.epmd.port", "Erlang Port Mapper Daemon Listener Port", 4369);
 
-    @SetFromFlag("erlangPortRange")
-    ConfigKey<PortRange> ERLANG_PORT_RANGE = ConfigKeys.newConfigKey(PortRange.class, "riak.erlang.portrange.internal", "Erlang Port Range", new PortRanges.LinearPortRange(6000, 7999));
-
-    // TODO Change {@link #ERLANG_PORT_RANGE_START} and {@link #ERLANG_PORT_RANGE_END} to sensors
-
-    /** @deprecated since 0.10.0; use {@link #ERLANG_PORT_RANGE} instead */
-    @Deprecated
     @SetFromFlag("erlangPortRangeStart")
-    AttributeSensorAndConfigKey<Integer, Integer> ERLANG_PORT_RANGE_START = ConfigKeys.newIntegerSensorAndConfigKey("riak.erlang.portrange.start.internal", "Erlang Port Range Start");
+    AttributeSensorAndConfigKey<Integer, Integer> ERLANG_PORT_RANGE_START = ConfigKeys.newIntegerSensorAndConfigKey("riak.erlang.portrange.start", "Erlang Port Range Start");
 
-    /** @deprecated since 0.10.0; use {@link #ERLANG_PORT_RANGE} instead */
-    @Deprecated
     @SetFromFlag("erlangPortRangeEnd")
-    AttributeSensorAndConfigKey<Integer, Integer> ERLANG_PORT_RANGE_END = ConfigKeys.newIntegerSensorAndConfigKey("riak.erlang.portrange.end.internal", "Erlang Port Range End");
+    AttributeSensorAndConfigKey<Integer, Integer> ERLANG_PORT_RANGE_END = ConfigKeys.newIntegerSensorAndConfigKey("riak.erlang.portrange.end", "Erlang Port Range End");
 
     @SetFromFlag("configInternalNetworking")
     ConfigKey<Boolean> CONFIGURE_INTERNAL_NETWORKING = ConfigKeys.newBooleanConfigKey("riak.networking.internal", "Set up internal networking for intra-node communication", Boolean.TRUE);

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/riak/RiakNode.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/riak/RiakNode.java
@@ -107,10 +107,10 @@ public interface RiakNode extends SoftwareProcess, UsesJava {
 
     // NB these two needed for clients to access
     @SetFromFlag("riakWebPort")
-    PortAttributeSensorAndConfigKey RIAK_WEB_PORT = ConfigKeys.newPortSensorAndConfigKey("riak.web.port", "Riak Web Port", "8098+");
+    PortAttributeSensorAndConfigKey RIAK_WEB_PORT = ConfigKeys.newPortSensorAndConfigKey("riak.webPort", "Riak Web Port", "8098+");
 
     @SetFromFlag("riakPbPort")
-    PortAttributeSensorAndConfigKey RIAK_PB_PORT = ConfigKeys.newPortSensorAndConfigKey("riak.pb.port", "Riak Protocol Buffers Port", "8087+");
+    PortAttributeSensorAndConfigKey RIAK_PB_PORT = ConfigKeys.newPortSensorAndConfigKey("riak.pbPort", "Riak Protocol Buffers Port", "8087+");
 
     @SetFromFlag("useHttpMonitoring")
     ConfigKey<Boolean> USE_HTTP_MONITORING = ConfigKeys.newConfigKey("httpMonitoring.enabled", "HTTP(S) monitoring enabled", Boolean.TRUE);
@@ -131,10 +131,10 @@ public interface RiakNode extends SoftwareProcess, UsesJava {
      */
 
     @SetFromFlag("handoffListenerPort")
-    ConfigKey<Integer> HANDOFF_LISTENER_PORT = ConfigKeys.newIntegerConfigKey("riak.handoff.port", "Handoff Listener Port", 8099);
+    AttributeSensorAndConfigKey<Integer, Integer> HANDOFF_LISTENER_PORT = ConfigKeys.newIntegerSensorAndConfigKey("riak.handoff.port", "Handoff Listener Port", 8099);
 
     @SetFromFlag("epmdListenerPort")
-    ConfigKey<Integer> EPMD_LISTENER_PORT = ConfigKeys.newIntegerConfigKey("riak.epmd.port", "Erlang Port Mapper Daemon Listener Port", 4369);
+    AttributeSensorAndConfigKey<Integer, Integer> EPMD_LISTENER_PORT = ConfigKeys.newIntegerSensorAndConfigKey("riak.epmd.port", "Erlang Port Mapper Daemon Listener Port", 4369);
 
     @SetFromFlag("erlangPortRangeStart")
     AttributeSensorAndConfigKey<Integer, Integer> ERLANG_PORT_RANGE_START = ConfigKeys.newIntegerSensorAndConfigKey("riak.erlang.portrange.start", "Erlang Port Range Start");

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeImpl.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeImpl.java
@@ -22,12 +22,25 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nullable;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
+import com.google.common.net.HostAndPort;
+
+import org.jclouds.net.domain.IpPermission;
+import org.jclouds.net.domain.IpProtocol;
+
+import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.api.location.MachineProvisioningLocation;
+import org.apache.brooklyn.api.location.PortRange;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.core.location.access.BrooklynAccessUtils;
@@ -39,22 +52,20 @@ import org.apache.brooklyn.entity.webapp.WebAppServiceMethods;
 import org.apache.brooklyn.feed.http.HttpFeed;
 import org.apache.brooklyn.feed.http.HttpPollConfig;
 import org.apache.brooklyn.feed.http.HttpValueFunctions;
-import org.apache.brooklyn.util.collections.MutableSet;
+import org.apache.brooklyn.location.jclouds.JcloudsMachineLocation;
+import org.apache.brooklyn.location.jclouds.JcloudsSshMachineLocation;
+import org.apache.brooklyn.location.jclouds.networking.JcloudsLocationSecurityGroupCustomizer;
+import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.guava.Functionals;
+import org.apache.brooklyn.util.net.Cidr;
 import org.apache.brooklyn.util.time.Duration;
-
-import com.google.common.base.Function;
-import com.google.common.base.Functions;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ContiguousSet;
-import com.google.common.collect.DiscreteDomain;
-import com.google.common.collect.Range;
-import com.google.common.net.HostAndPort;
 
 public class RiakNodeImpl extends SoftwareProcessImpl implements RiakNode {
 
-    private volatile HttpFeed httpFeed;
+    private static final Logger LOG = LoggerFactory.getLogger(RiakNodeImpl.class);
+
+    private transient HttpFeed httpFeed;
 
     @Override
     public RiakNodeDriver getDriver() {
@@ -99,16 +110,58 @@ public class RiakNodeImpl extends SoftwareProcessImpl implements RiakNode {
 
     @Override
     protected Collection<Integer> getRequiredOpenPorts() {
-        // TODO this creates a huge list of inbound ports; much better to define on a security group using range syntax!
-        int erlangRangeStart = getConfig(ERLANG_PORT_RANGE_START).iterator().next();
-        int erlangRangeEnd = getConfig(ERLANG_PORT_RANGE_END).iterator().next();
+        PortRange erlangPorts = config().get(ERLANG_PORT_RANGE);
+        Integer erlangRangeStart = config().get(ERLANG_PORT_RANGE_START);
+        Integer erlangRangeEnd = config().get(ERLANG_PORT_RANGE_END);
+        if (erlangRangeStart == null) erlangRangeStart = Iterables.get(erlangPorts, 0);
+        if (erlangRangeEnd == null) erlangRangeEnd = Iterables.getLast(erlangPorts);
+        sensors().set(ERLANG_PORT_RANGE_START, erlangRangeStart);
+        sensors().set(ERLANG_PORT_RANGE_END, erlangRangeEnd);
 
-        Set<Integer> ports = MutableSet.copyOf(super.getRequiredOpenPorts());
-        Set<Integer> erlangPorts = ContiguousSet.create(Range.open(erlangRangeStart, erlangRangeEnd), DiscreteDomain.integers());
-        ports.addAll(erlangPorts);
+        boolean configureInternalNetworking = config().get(CONFIGURE_INTERNAL_NETWORKING);
+        if (configureInternalNetworking) {
+            configureInternalNetworking();
+        }
 
-        return ports;
+        return super.getRequiredOpenPorts();
     }
+
+    private void configureInternalNetworking() {
+        Location location = getDriver().getLocation();
+        if (!(location instanceof JcloudsSshMachineLocation)) {
+            LOG.info("Not running in a JcloudsSshMachineLocation, not adding IP permissions to {}", this);
+            return;
+        }
+        JcloudsMachineLocation machine = (JcloudsMachineLocation) location;
+        JcloudsLocationSecurityGroupCustomizer customizer = JcloudsLocationSecurityGroupCustomizer.getInstance(getApplicationId());
+
+        synchronized (getParent()) {
+            String cidr = Cidr.UNIVERSAL.toString(); // TODO configure with a more restrictive CIDR
+            Collection<IpPermission> permissions = MutableList.<IpPermission>builder()
+                    .add(IpPermission.builder()
+                            .ipProtocol(IpProtocol.TCP)
+                            .fromPort(sensors().get(ERLANG_PORT_RANGE_START))
+                            .toPort(sensors().get(ERLANG_PORT_RANGE_END))
+                            .cidrBlock(cidr)
+                            .build())
+                    .add(IpPermission.builder()
+                            .ipProtocol(IpProtocol.TCP)
+                            .fromPort(config().get(HANDOFF_LISTENER_PORT))
+                            .toPort(config().get(HANDOFF_LISTENER_PORT))
+                            .cidrBlock(cidr)
+                            .build())
+                    .add(IpPermission.builder()
+                            .ipProtocol(IpProtocol.TCP)
+                            .fromPort(config().get(EPMD_LISTENER_PORT))
+                            .toPort(config().get(EPMD_LISTENER_PORT))
+                            .cidrBlock(cidr)
+                            .build())
+                     .build();
+            LOG.debug("Applying custom security groups to {}: {}", machine, permissions);
+            customizer.addPermissionsToLocation(machine, permissions);
+        }
+    }
+
 
     @Override
     public void connectSensors() {
@@ -248,6 +301,7 @@ public class RiakNodeImpl extends SoftwareProcessImpl implements RiakNode {
     protected boolean isHttpMonitoringEnabled() {
         return Boolean.TRUE.equals(getConfig(USE_HTTP_MONITORING));
     }
+
     @Override
     public Integer getRiakWebPort() {
         return getAttribute(RiakNode.RIAK_WEB_PORT);
@@ -260,12 +314,12 @@ public class RiakNodeImpl extends SoftwareProcessImpl implements RiakNode {
 
     @Override
     public Integer getHandoffListenerPort() {
-        return getAttribute(RiakNode.HANDOFF_LISTENER_PORT);
+        return getConfig(RiakNode.HANDOFF_LISTENER_PORT);
     }
 
     @Override
     public Integer getEpmdListenerPort() {
-        return getAttribute(RiakNode.EPMD_LISTENER_PORT);
+        return getConfig(RiakNode.EPMD_LISTENER_PORT);
     }
 
     @Override


### PR DESCRIPTION
Configure the internal ports required for Riak intra-node communication using an optional `JcloudsSecurityGroupCustomizer`