### PR TITLE
Fix NodeJsWebAppSshDriver to obtain properly MAIN_URL

### DIFF
--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/JavaWebAppSshDriver.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/JavaWebAppSshDriver.java
@@ -91,25 +91,17 @@ public abstract class JavaWebAppSshDriver extends JavaSoftwareProcessSshDriver i
         return (ssl == null) ? null : ssl.getKeyAlias();
     }
 
+    /**
+     * @deprecated since 0.10.0; please use {@link WebAppServiceMethods#inferBrooklynAccessibleRootUrl(org.apache.brooklyn.api.entity.Entity)}
+     */
+    @Deprecated
     protected String inferRootUrl() {
-        if (isProtocolEnabled("https")) {
-            Integer port = getHttpsPort();
-            checkNotNull(port, "HTTPS_PORT sensors not set; is an acceptable port available?");
-            HostAndPort accessibleAddress = BrooklynAccessUtils.getBrooklynAccessibleAddress(getEntity(), port);
-            return String.format("https://%s:%s/", accessibleAddress.getHostText(), accessibleAddress.getPort());
-        } else if (isProtocolEnabled("http")) {
-            Integer port = getHttpPort();
-            checkNotNull(port, "HTTP_PORT sensors not set; is an acceptable port available?");
-            HostAndPort accessibleAddress = BrooklynAccessUtils.getBrooklynAccessibleAddress(getEntity(), port);
-            return String.format("http://%s:%s/", accessibleAddress.getHostText(), accessibleAddress.getPort());
-        } else {
-            throw new IllegalStateException("HTTP and HTTPS protocols not enabled for "+entity+"; enabled protocols are "+getEnabledProtocols());
-        }
+        return WebAppServiceMethods.inferBrooklynAccessibleRootUrl(entity);
     }
-    
+
     @Override
     public void postLaunch() {
-        String rootUrl = inferRootUrl();
+        String rootUrl = WebAppServiceMethods.inferBrooklynAccessibleRootUrl(entity);
         entity.sensors().set(Attributes.MAIN_URI, URI.create(rootUrl));
         entity.sensors().set(WebAppService.ROOT_URL, rootUrl);
     }

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/nodejs/NodeJsWebAppSshDriver.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/nodejs/NodeJsWebAppSshDriver.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.brooklyn.entity.webapp.WebAppServiceMethods;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,9 +32,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 
 import org.apache.brooklyn.core.entity.Attributes;
-import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.entity.software.base.AbstractSoftwareProcessSshDriver;
-import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.entity.webapp.WebAppService;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
 import org.apache.brooklyn.util.collections.MutableList;
@@ -68,7 +67,7 @@ public class NodeJsWebAppSshDriver extends AbstractSoftwareProcessSshDriver impl
 
     @Override
     public void postLaunch() {
-        String rootUrl = String.format("http://%s:%d/", getHostname(), getHttpPort());
+        String rootUrl = WebAppServiceMethods.inferBrooklynAccessibleRootUrl(entity);
         entity.sensors().set(Attributes.MAIN_URI, URI.create(rootUrl));
         entity.sensors().set(WebAppService.ROOT_URL, rootUrl);
     }


### PR DESCRIPTION
- make NodeJsWebAppSshDriver and JavaWebAppSshDriver to use a single method
  for obtaining the MAIN_URL

This should be a standardized for all entities which has to have
an option for exposing http MAIN_URL