### PR TITLE
Fix riak (configureInternalNetwork throwing NPE)

### DIFF
--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/riak/RiakNode.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/riak/RiakNode.java
@@ -137,10 +137,10 @@ public interface RiakNode extends SoftwareProcess, UsesJava {
     AttributeSensorAndConfigKey<Integer, Integer> EPMD_LISTENER_PORT = ConfigKeys.newIntegerSensorAndConfigKey("riak.epmd.port", "Erlang Port Mapper Daemon Listener Port", 4369);
 
     @SetFromFlag("erlangPortRangeStart")
-    AttributeSensorAndConfigKey<Integer, Integer> ERLANG_PORT_RANGE_START = ConfigKeys.newIntegerSensorAndConfigKey("riak.erlang.portrange.start", "Erlang Port Range Start");
+    AttributeSensorAndConfigKey<Integer, Integer> ERLANG_PORT_RANGE_START = ConfigKeys.newIntegerSensorAndConfigKey("riak.erlang.portrange.start", "Erlang Port Range Start", 6000);
 
     @SetFromFlag("erlangPortRangeEnd")
-    AttributeSensorAndConfigKey<Integer, Integer> ERLANG_PORT_RANGE_END = ConfigKeys.newIntegerSensorAndConfigKey("riak.erlang.portrange.end", "Erlang Port Range End");
+    AttributeSensorAndConfigKey<Integer, Integer> ERLANG_PORT_RANGE_END = ConfigKeys.newIntegerSensorAndConfigKey("riak.erlang.portrange.end", "Erlang Port Range End", 7999);
 
     @SetFromFlag("configInternalNetworking")
     ConfigKey<Boolean> CONFIGURE_INTERNAL_NETWORKING = ConfigKeys.newBooleanConfigKey("riak.networking.internal", "Set up internal networking for intra-node communication", Boolean.TRUE);

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeImpl.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/riak/RiakNodeImpl.java
@@ -113,14 +113,20 @@ public class RiakNodeImpl extends SoftwareProcessImpl implements RiakNode {
         sensors().set(ERLANG_PORT_RANGE_START, erlangRangeStart);
         sensors().set(ERLANG_PORT_RANGE_END, erlangRangeEnd);
 
-        boolean configureInternalNetworking = config().get(CONFIGURE_INTERNAL_NETWORKING);
-        if (configureInternalNetworking) {
-            configureInternalNetworking();
-        }
-
         return super.getRequiredOpenPorts();
     }
 
+    // Called after machine is provisioned, but before the driver tries to install Riak
+    @Override
+    protected void preStart() {
+        super.preStart();
+        
+        boolean configureInternalNetworking = Boolean.TRUE.equals(config().get(CONFIGURE_INTERNAL_NETWORKING));
+        if (configureInternalNetworking) {
+            configureInternalNetworking();
+        }
+    }
+    
     private void configureInternalNetworking() {
         Location location = getDriver().getLocation();
         if (!(location instanceof JcloudsSshMachineLocation)) {


### PR DESCRIPTION
Calling `configureInternalNetworking()` in `getRequiredOpenPorts()` always caused an NPE, because the driver was not yet initialised. Also the sensor `ERLANG_PORT_RANGE_START` was always null, because the config had no default value.

We unfortunately broke this in https://github.com/apache/brooklyn-library/pull/44.