### PR TITLE
Move karaf distribution to brooklyn-dist.

### DIFF
--- a/karaf/catalog/pom.xml
+++ b/karaf/catalog/pom.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.brooklyn</groupId>
+        <artifactId>brooklyn-library-karaf</artifactId>
+        <version>0.10.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>brooklyn-library-catalog</artifactId>
+    <name>Brooklyn Library Catalog</name>
+    <description>Defines catalog items for Karaf runtime</description>
+    <packaging>jar</packaging>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <extensions>true</extensions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+
+</project>

--- a/karaf/catalog/src/main/resources/library-catalog-classes.bom
+++ b/karaf/catalog/src/main/resources/library-catalog-classes.bom
@@ -1,0 +1,402 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+brooklyn.catalog:
+  version: "0.10.0-SNAPSHOT" # BROOKLYN_VERSION
+  include: classpath://catalog-classes.bom
+
+  items:
+
+  # org.apache.brooklyn.software-webapp
+  - itemType: entity
+    items:
+    - id: org.apache.brooklyn.entity.webapp.nodejs.NodeJsWebAppService
+      iconUrl: classpath:///nodejs-logo.png
+      item:
+        type: org.apache.brooklyn.entity.webapp.nodejs.NodeJsWebAppService
+        name: Node.JS Application
+    - id: org.apache.brooklyn.entity.webapp.jboss.JBoss7Server
+      iconUrl: classpath:///jboss-logo.png
+      item:
+        type: org.apache.brooklyn.entity.webapp.jboss.JBoss7Server
+        name: JBoss Application Server 7
+        description: AS7 - an open source Java application server from JBoss
+    - id: org.apache.brooklyn.entity.proxy.nginx.UrlMapping
+      item:
+        type: org.apache.brooklyn.entity.proxy.nginx.UrlMapping
+    - id: org.apache.brooklyn.entity.webapp.DynamicWebAppFabric
+      item:
+        type: org.apache.brooklyn.entity.webapp.DynamicWebAppFabric
+    - id: org.apache.brooklyn.entity.proxy.nginx.NginxController
+      iconUrl: classpath:///nginx-logo.jpeg
+      item:
+        type: org.apache.brooklyn.entity.proxy.nginx.NginxController
+        name: Nginx Server
+        description: A single Nginx server. Provides HTTP and reverse proxy services
+    - id: org.apache.brooklyn.entity.webapp.jboss.JBoss6Server
+      iconUrl: classpath:///jboss-logo.png
+      item:
+        type: org.apache.brooklyn.entity.webapp.jboss.JBoss6Server
+        name: JBoss Application Server 6
+        description: AS6 -  an open source Java application server from JBoss
+    - id: org.apache.brooklyn.entity.webapp.tomcat.Tomcat8Server
+      iconUrl: classpath:///tomcat-logo.png
+      item:
+        type: org.apache.brooklyn.entity.webapp.tomcat.Tomcat8Server
+        name: Tomcat 8 Server
+    - id: org.apache.brooklyn.entity.proxy.LoadBalancerCluster
+      item:
+        type: org.apache.brooklyn.entity.proxy.LoadBalancerCluster
+    - id: org.apache.brooklyn.entity.webapp.jetty.Jetty6Server
+      iconUrl: classpath:///jetty-logo.png
+      item:
+        type: org.apache.brooklyn.entity.webapp.jetty.Jetty6Server
+        name: Jetty6 Server
+        description: Old version (v6 @ Mortbay) of the popular Jetty webapp container
+    - id: org.apache.brooklyn.entity.webapp.DynamicWebAppCluster
+      item:
+        type: org.apache.brooklyn.entity.webapp.DynamicWebAppCluster
+        name: Dynamic Web-app Cluster
+        description: A cluster of web-apps, which can be dynamically re-sized; this does not include a load-balancer
+    - id: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
+      iconUrl: classpath:///tomcat-logo.png
+      item:
+        type: org.apache.brooklyn.entity.webapp.tomcat.TomcatServer
+        name: Tomcat 7 Server
+    - id: org.apache.brooklyn.entity.dns.geoscaling.GeoscalingDnsService
+      iconUrl: classpath:///geoscaling-logo.gif
+      item:
+        type: org.apache.brooklyn.entity.dns.geoscaling.GeoscalingDnsService
+    - id: org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster
+      item:
+        type: org.apache.brooklyn.entity.webapp.ControlledDynamicWebAppCluster
+        name: Controlled Dynamic Web-app Cluster
+        description: A cluster of load-balanced web-apps, which can be dynamically re-sized
+
+  # org.apache.brooklyn.software-osgi
+  - itemType: entity
+    items:
+    - id: org.apache.brooklyn.entity.osgi.karaf.KarafContainer
+      iconUrl: classpath:///karaf-logo.png
+      item:
+        type: org.apache.brooklyn.entity.osgi.karaf.KarafContainer
+        name: Karaf
+        description: Apache Karaf is a small OSGi based runtime which provides a lightweight container onto which various components and applications can be deployed.
+
+  # org.apache.brooklyn.software-nosql
+  - itemType: entity
+    items:
+    - id: org.apache.brooklyn.entity.nosql.redis.RedisStore
+      iconUrl: classpath:///redis-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.redis.RedisStore
+        name: Redis Server
+        description: Redis is an open-source, networked, in-memory, key-value data store with optional durability
+    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBRouterCluster
+      iconUrl: classpath:///mongodb-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBRouterCluster
+    - id: org.apache.brooklyn.entity.nosql.cassandra.CassandraDatacenter
+      iconUrl: classpath:///cassandra-logo.jpeg
+      item:
+        type: org.apache.brooklyn.entity.nosql.cassandra.CassandraDatacenter
+        name: Apache Cassandra Datacenter Cluster
+        description: Cassandra is a highly scalable, eventually
+    - id: org.apache.brooklyn.entity.nosql.solr.SolrServer
+      iconUrl: classpath:///solr-logo.jpeg
+      item:
+        type: org.apache.brooklyn.entity.nosql.solr.SolrServer
+        name: Apache Solr Node
+        description: Solr is the popular, blazing fast open source enterprise search
+    - id: org.apache.brooklyn.entity.nosql.couchdb.CouchDBNode
+      iconUrl: classpath:///couchdb-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.couchdb.CouchDBNode
+        name: CouchDB Node
+    - id: org.apache.brooklyn.entity.nosql.redis.RedisShard
+      iconUrl: classpath:///redis-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.redis.RedisShard
+    - id: org.apache.brooklyn.entity.nosql.redis.RedisCluster
+      iconUrl: classpath:///redis-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.redis.RedisCluster
+        name: Redis Cluster
+        description: Redis is an open-source, networked, in-memory, key-value data store with optional durability
+    - id: org.apache.brooklyn.entity.nosql.hazelcast.HazelcastCluster
+      iconUrl: classpath:///hazelcast-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.hazelcast.HazelcastCluster
+        name: Hazelcast Cluster
+        description: Hazelcast is a clustering and highly scalable data distribution platform for Java.
+    - id: org.apache.brooklyn.entity.nosql.couchdb.CouchDBCluster
+      iconUrl: classpath:///couchdb-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.couchdb.CouchDBCluster
+    - id: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseNode
+      iconUrl: classpath:///couchbase-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseNode
+        name: CouchBase Node
+        description: Couchbase Server is an open source, distributed (shared-nothing architecture)
+    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBShardedDeployment
+      iconUrl: classpath:///mongodb-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBShardedDeployment
+        name: MongoDB Sharded Deployment
+    - id: org.apache.brooklyn.entity.nosql.cassandra.CassandraNode
+      iconUrl: classpath:///cassandra-logo.jpeg
+      item:
+        type: org.apache.brooklyn.entity.nosql.cassandra.CassandraNode
+        name: Apache Cassandra Node
+        description: Cassandra is a highly scalable, eventually
+    - id: org.apache.brooklyn.entity.nosql.riak.RiakNode
+      iconUrl: classpath:///org/apache/brooklyn/entity/nosql/riak/riak.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.riak.RiakNode
+        name: Riak Node
+        description: Riak is a distributed NoSQL key-value data store that offers
+    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBConfigServerCluster
+      iconUrl: classpath:///mongodb-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBConfigServerCluster
+    - id: org.apache.brooklyn.entity.nosql.mongodb.MongoDBServer
+      iconUrl: classpath:///mongodb-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.MongoDBServer
+        name: MongoDB Server
+    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBRouter
+      iconUrl: classpath:///mongodb-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBRouter
+        name: MongoDB Router
+    - id: org.apache.brooklyn.entity.nosql.mongodb.MongoDBReplicaSet
+      iconUrl: classpath:///mongodb-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.MongoDBReplicaSet
+    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBShardCluster
+      iconUrl: classpath:///mongodb-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBShardCluster
+    - id: org.apache.brooklyn.entity.nosql.mongodb.MongoDBClient
+      iconUrl: classpath:///mongodb-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.MongoDBClient
+    - id: org.apache.brooklyn.entity.nosql.elasticsearch.ElasticSearchNode
+      item:
+        type: org.apache.brooklyn.entity.nosql.elasticsearch.ElasticSearchNode
+        name: Elastic Search Node
+        description: Elasticsearch is an open-source search server based on Lucene.
+    - id: org.apache.brooklyn.entity.nosql.cassandra.CassandraFabric
+      iconUrl: classpath:///cassandra-logo.jpeg
+      item:
+        type: org.apache.brooklyn.entity.nosql.cassandra.CassandraFabric
+        name: Apache Cassandra Database Fabric
+        description: Cassandra is a highly scalable, eventually
+    - id: org.apache.brooklyn.entity.nosql.elasticsearch.ElasticSearchCluster
+      item:
+        type: org.apache.brooklyn.entity.nosql.elasticsearch.ElasticSearchCluster
+        name: Elastic Search Cluster
+        description: Elasticsearch is an open-source search server based on Lucene.
+    - id: org.apache.brooklyn.entity.nosql.cassandra.CassandraCluster
+      iconUrl: classpath:///cassandra-logo.jpeg
+      item:
+        type: org.apache.brooklyn.entity.nosql.cassandra.CassandraCluster
+    - id: org.apache.brooklyn.entity.nosql.redis.RedisSlave
+      iconUrl: classpath:///redis-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.redis.RedisSlave
+    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBConfigServer
+      iconUrl: classpath:///mongodb-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.MongoDBConfigServer
+    - id: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseCluster
+      iconUrl: classpath:///couchbase-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseCluster
+        name: CouchBase Cluster
+        description: Couchbase is an open source, distributed (shared-nothing architecture)
+    - id: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseSyncGateway
+      iconUrl: classpath:///couchbase-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.couchbase.CouchbaseSyncGateway
+    - id: org.apache.brooklyn.entity.nosql.hazelcast.HazelcastNode
+      iconUrl: classpath:///hazelcast-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.hazelcast.HazelcastNode
+        name: Hazelcast Node
+        description: Hazelcast is a clustering and highly scalable data distribution platform for Java.
+    - id: org.apache.brooklyn.entity.nosql.riak.RiakCluster
+      iconUrl: classpath:///org/apache/brooklyn/entity/nosql/riak/riak.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.riak.RiakCluster
+        name: Riak Cluster
+        description: Riak is a distributed NoSQL key-value data store that offers
+    - id: org.apache.brooklyn.entity.nosql.mongodb.sharding.CoLocatedMongoDBRouter
+      iconUrl: classpath:///mongodb-logo.png
+      item:
+        type: org.apache.brooklyn.entity.nosql.mongodb.sharding.CoLocatedMongoDBRouter
+
+  # org.apache.brooklyn.software-network
+  - itemType: entity
+    items:
+    - id: org.apache.brooklyn.entity.network.bind.BindDnsServer
+      description: BIND is an Internet Domain Name Server.
+      item:
+        type: org.apache.brooklyn.entity.network.bind.BindDnsServer
+        name: BIND
+
+  # org.apache.brooklyn.software-monitoring
+  - itemType: entity
+    items:
+    - id: org.apache.brooklyn.entity.monitoring.monit.MonitNode
+      iconUrl: classpath:///monit-logo.png
+      item:
+        type: org.apache.brooklyn.entity.monitoring.monit.MonitNode
+        name: Monit Node
+        description: Monit is a free open source utility for managing and monitoring, processes, programs, files, directories and filesystems on a UNIX system
+
+  # org.apache.brooklyn.software-messaging
+  - itemType: entity
+    items:
+    - id: org.apache.brooklyn.entity.messaging.activemq.ActiveMQBroker
+      iconUrl: classpath:///activemq-logo.png
+      item:
+        type: org.apache.brooklyn.entity.messaging.activemq.ActiveMQBroker
+        name: ActiveMQ Broker
+        description: ActiveMQ is an open source message broker which fully implements the Java Message Service 1.1 (JMS)
+    - id: org.apache.brooklyn.entity.messaging.qpid.QpidBroker
+      iconUrl: classpath:///qpid-logo.jpeg
+      item:
+        type: org.apache.brooklyn.entity.messaging.qpid.QpidBroker
+        name: Qpid Broker
+        description: Apache Qpid is an open-source messaging system, implementing the Advanced Message Queuing Protocol (AMQP)
+    - id: org.apache.brooklyn.entity.messaging.storm.Storm
+      iconUrl: classpath:///apache-storm-logo.png
+      item:
+        type: org.apache.brooklyn.entity.messaging.storm.Storm
+        name: Storm Node
+        description: Apache Storm is a distributed realtime computation system.
+    - id: org.apache.brooklyn.entity.messaging.kafka.KafkaCluster
+      iconUrl: classpath:///kafka-logo.png
+      item:
+        type: org.apache.brooklyn.entity.messaging.kafka.KafkaCluster
+        name: Kafka
+        description: Apache Kafka is a distributed publish-subscribe messaging system
+    - id: org.apache.brooklyn.entity.messaging.activemq.ActiveMQQueue
+      iconUrl: classpath:///activemq-logo.png
+      item:
+        type: org.apache.brooklyn.entity.messaging.activemq.ActiveMQQueue
+    - id: org.apache.brooklyn.entity.zookeeper.ZooKeeperEnsemble
+      iconUrl: classpath:///zookeeper_logo.gif
+      item:
+        type: org.apache.brooklyn.entity.zookeeper.ZooKeeperEnsemble
+        name: ZooKeeper ensemble
+        description: A cluster of ZooKeeper servers.
+    - id: org.apache.brooklyn.entity.messaging.kafka.KafkaZooKeeper
+      iconUrl: classpath:///zookeeper_logo.gif
+      item:
+        type: org.apache.brooklyn.entity.messaging.kafka.KafkaZooKeeper
+    - id: org.apache.brooklyn.entity.messaging.activemq.ActiveMQTopic
+      iconUrl: classpath:///activemq-logo.png
+      item:
+        type: org.apache.brooklyn.entity.messaging.activemq.ActiveMQTopic
+    - id: org.apache.brooklyn.entity.messaging.qpid.QpidQueue
+      iconUrl: classpath:///qpid-logo.jpeg
+      item:
+        type: org.apache.brooklyn.entity.messaging.qpid.QpidQueue
+    - id: org.apache.brooklyn.entity.zookeeper.ZooKeeperNode
+      iconUrl: classpath:///zookeeper_logo.gif
+      item:
+        type: org.apache.brooklyn.entity.zookeeper.ZooKeeperNode
+        name: ZooKeeper Node
+        description: Apache ZooKeeper is a server which enables
+    - id: org.apache.brooklyn.entity.messaging.rabbit.RabbitBroker
+      iconUrl: classpath:///RabbitMQLogo.png
+      item:
+        type: org.apache.brooklyn.entity.messaging.rabbit.RabbitBroker
+        name: RabbitMQ Broker
+        description: RabbitMQ is an open source message broker software (i.e. message-oriented middleware) that implements the Advanced Message Queuing Protocol (AMQP) standard
+    - id: org.apache.brooklyn.entity.messaging.kafka.KafkaBroker
+      iconUrl: classpath:///kafka-logo.png
+      item:
+        type: org.apache.brooklyn.entity.messaging.kafka.KafkaBroker
+    - id: org.apache.brooklyn.entity.messaging.qpid.QpidTopic
+      iconUrl: classpath:///qpid-logo.jpeg
+      item:
+        type: org.apache.brooklyn.entity.messaging.qpid.QpidTopic
+    - id: org.apache.brooklyn.entity.messaging.storm.StormDeployment
+      iconUrl: classpath:///apache-storm-logo.png
+      item:
+        type: org.apache.brooklyn.entity.messaging.storm.StormDeployment
+        name: Storm Deployment
+        description: A Storm cluster. Apache Storm is a distributed realtime computation system.
+
+  # org.apache.brooklyn.software-database
+  - itemType: entity
+    items:
+    - id: org.apache.brooklyn.entity.database.crate.CrateNode
+      iconUrl: classpath:///crate-logo.png
+      item:
+        type: org.apache.brooklyn.entity.database.crate.CrateNode
+    - id: org.apache.brooklyn.entity.database.mysql.MySqlNode
+      iconUrl: classpath:///mysql-logo-110x57.png
+      item:
+        type: org.apache.brooklyn.entity.database.mysql.MySqlNode
+        name: MySql Node
+        description: MySql is an open source relational database management system (RDBMS)
+    - id: org.apache.brooklyn.entity.database.mysql.MySqlCluster
+      iconUrl: classpath:///mysql-logo-110x57.png
+      item:
+        type: org.apache.brooklyn.entity.database.mysql.MySqlCluster
+        name: MySql Master-Slave cluster
+        description: Sets up a cluster of MySQL nodes using master-slave relation and binary logging
+    - id: org.apache.brooklyn.entity.database.postgresql.PostgreSqlNode
+      iconUrl: classpath:///postgresql-logo-200px.png
+      item:
+        type: org.apache.brooklyn.entity.database.postgresql.PostgreSqlNode
+        name: PostgreSQL Node
+        description: PostgreSQL is an object-relational database management system (ORDBMS)
+    - id: org.apache.brooklyn.entity.database.rubyrep.RubyRepNode
+      item:
+        type: org.apache.brooklyn.entity.database.rubyrep.RubyRepNode
+    - id: org.apache.brooklyn.entity.database.mariadb.MariaDbNode
+      iconUrl: classpath:///mariadb-logo-180x119.png
+      item:
+        type: org.apache.brooklyn.entity.database.mariadb.MariaDbNode
+        name: MariaDB Node
+        description: MariaDB is an open source relational database management system (RDBMS)
+
+  # org.apache.brooklyn.software-cm-salt
+  - itemType: entity
+    items:
+    - id: org.apache.brooklyn.entity.cm.salt.SaltEntity
+      iconUrl: classpath:///saltstack-logo.png
+      item:
+        type: org.apache.brooklyn.entity.cm.salt.SaltEntity
+        name: SaltEntity
+        description: Software managed by Salt CM
+
+  # org.apache.brooklyn.software-cm-ansible
+  - itemType: entity
+    items:
+    - id: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
+      iconUrl: classpath:///ansible-logo.png
+      item:
+        type: org.apache.brooklyn.entity.cm.ansible.AnsibleEntity
+        name: AnsibleEntity
+        description: Software managed by Ansible CM

--- a/karaf/features/pom.xml
+++ b/karaf/features/pom.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.brooklyn</groupId>
+        <artifactId>brooklyn-library-karaf</artifactId>
+        <version>0.10.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
+    </parent>
+
+    <artifactId>brooklyn-library-features</artifactId>
+    <name>Brooklyn Library Karaf Features</name>
+    <description>Defines Karaf features for Karaf runtime</description>
+    <packaging>feature</packaging>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.karaf.tooling</groupId>
+                    <artifactId>karaf-maven-plugin</artifactId>
+                    <version>4.0.1</version>
+                    <extensions>true</extensions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.karaf.tooling</groupId>
+                <artifactId>karaf-maven-plugin</artifactId>
+
+                <configuration>
+                    <startLevel>50</startLevel>
+                    <aggregateFeatures>true</aggregateFeatures>
+                    <resolver>(obr)</resolver>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.2.0"
+          name="org.apache.brooklyn-${project.version}"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:noNamespaceSchemaLocation="http://karaf.apache.org/xmlns/features/v1.2.0">
+
+    <feature name="brooklyn-software-network" version="${project.version}" description="Brooklyn Network Software Entities">
+        <bundle>mvn:org.apache.brooklyn/brooklyn-software-network/${project.version}</bundle>
+        <feature>brooklyn-software-base</feature>
+    </feature>
+
+    <feature name="brooklyn-software-cm" version="${project.version}" description="Configuration Management modules">
+        <bundle>mvn:org.apache.brooklyn/brooklyn-software-cm-salt/${project.version}</bundle>
+        <bundle>mvn:org.apache.brooklyn/brooklyn-software-cm-ansible/${project.version}</bundle>
+    </feature>
+
+    <feature name="brooklyn-software-osgi" version="${project.version}" description="Brooklyn OSGi Software Entities">
+        <bundle>mvn:org.apache.brooklyn/brooklyn-software-osgi/${project.version}</bundle>
+        <feature>brooklyn-core</feature>
+        <feature>brooklyn-api</feature>
+        <feature>brooklyn-software-base</feature>
+        <bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
+    </feature>
+
+    <feature name="brooklyn-software-database" version="${project.version}" description="Brooklyn Database Software Entities">
+        <bundle>mvn:org.apache.brooklyn/brooklyn-software-database/${project.version}</bundle>
+        <feature>brooklyn-core</feature>
+        <feature>brooklyn-api</feature>
+        <feature>brooklyn-software-base</feature>
+        <bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
+    </feature>
+
+    <feature name="brooklyn-software-webapp" version="${project.version}" description="Brooklyn Web App Software Entities">
+        <bundle>mvn:org.apache.brooklyn/brooklyn-software-webapp/${project.version}</bundle>
+        <feature>brooklyn-software-base</feature>
+        <bundle dependency="true">wrap:mvn:org.hibernate/jtidy/${jtidy.version}</bundle>
+    </feature>
+
+    <feature name="brooklyn-software-messaging" version="${project.version}" description="Brooklyn Messaging Software Entities">
+        <bundle>mvn:org.apache.brooklyn/brooklyn-software-messaging/${project.version}</bundle>
+        <feature>brooklyn-software-base</feature>
+    </feature>
+
+    <feature name="brooklyn-software-nosql" version="${project.version}" description="Brooklyn NoSQL Data Store Software Entities">
+        <bundle>mvn:org.apache.brooklyn/brooklyn-software-nosql/${project.version}</bundle>
+        <feature>brooklyn-software-base</feature>
+        <feature>brooklyn-software-database</feature>
+        <feature>brooklyn-software-webapp</feature>
+        <bundle dependency="true">mvn:org.mongodb/mongo-java-driver/3.0.3</bundle>
+    </feature>
+
+    <feature name="brooklyn-software-monitoring" version="${project.version}" description="Brooklyn Monitoring Software Entities">
+        <bundle>mvn:org.apache.brooklyn/brooklyn-software-monitoring/${project.version}</bundle>
+        <feature>brooklyn-core</feature>
+        <feature>brooklyn-api</feature>
+        <feature>brooklyn-software-base</feature>
+        <bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
+    </feature>
+
+    <feature name="brooklyn-library-all" version="${project.version}" description="Brooklyn All Library Entities">
+        <feature>brooklyn-software-network</feature>
+        <feature>brooklyn-software-cm</feature>
+        <feature>brooklyn-software-osgi</feature>
+        <feature>brooklyn-software-database</feature>
+        <feature>brooklyn-software-webapp</feature>
+        <feature>brooklyn-software-messaging</feature>
+        <feature>brooklyn-software-nosql</feature>
+        <feature>brooklyn-software-monitoring</feature>
+    </feature>
+
+
+</features>

--- a/karaf/pom.xml
+++ b/karaf/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+        <!--
+            Licensed to the Apache Software Foundation (ASF) under one
+            or more contributor license agreements.  See the NOTICE file
+            distributed with this work for additional information
+            regarding copyright ownership.  The ASF licenses this file
+            to you under the Apache License, Version 2.0 (the
+            "License"); you may not use this file except in compliance
+            with the License.  You may obtain a copy of the License at
+
+             http://www.apache.org/licenses/LICENSE-2.0
+
+            Unless required by applicable law or agreed to in writing,
+            software distributed under the License is distributed on an
+            "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+            KIND, either express or implied.  See the License for the
+            specific language governing permissions and limitations
+            under the License.
+        -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.apache.brooklyn</groupId>
+        <artifactId>brooklyn-library</artifactId>
+        <version>0.10.0-SNAPSHOT</version>  <!-- BROOKLYN_VERSION -->
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>brooklyn-library-karaf</artifactId>
+    <name>Brooklyn Library Karaf integration</name>
+    <description>Brooklyn Library Karaf integration</description>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>catalog</module>
+        <module>features</module>
+    </modules>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,7 @@
         
         <module>examples</module>
 
+        <module>karaf</module>
     </modules>
 
 </project>


### PR DESCRIPTION
This PR is the second of three that together move the karaf distribution to brooklyn-dist and separate out the software from brooklyn-library into separate catalog bom and feature files.

This change separates out the brooklyn-library releated features into
new projects in brooklyn-library itself.

Merge this after https://github.com/apache/brooklyn-server/pull/271.