### PR TITLE
add user sensor to MySqlNode

### DIFF
--- a/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlNode.java
+++ b/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlNode.java
@@ -62,12 +62,15 @@ public interface MySqlNode extends SoftwareProcess, HasShortName, DatastoreCommo
     @SetFromFlag("serverConf")
     MapConfigKey<Object> MYSQL_SERVER_CONF = new MapConfigKey<Object>(
             Object.class, "mysql.server.conf", "Configuration options for mysqld");
-    
+
     ConfigKey<Object> MYSQL_SERVER_CONF_LOWER_CASE_TABLE_NAMES = MYSQL_SERVER_CONF.subKey("lower_case_table_names", "See MySQL guide. Set 1 to ignore case in table names (useful for OS portability)");
-    
+
     @SetFromFlag("serverId")
     ConfigKey<Integer> MYSQL_SERVER_ID = ConfigKeys.newIntegerConfigKey("mysql.server_id", "Corresponds to server_id option", 0);
-    
+
+    @SetFromFlag("user")
+    AttributeSensor USER = Sensors.newStringSensor("mysql.user", "Database admin user (default is `root`)");
+
     @SetFromFlag("password")
     StringAttributeSensorAndConfigKey PASSWORD = new StringAttributeSensorAndConfigKey(
             "mysql.password", "Database admin password (or randomly generated if not set)", null);
@@ -78,7 +81,7 @@ public interface MySqlNode extends SoftwareProcess, HasShortName, DatastoreCommo
 
     @SetFromFlag("generalLog")
     ConfigKey GENERAL_LOG = ConfigKeys.newBooleanConfigKey("mysql.general_log", "Enable general log", false);
-    
+
     /** @deprecated since 0.7.0 use DATASTORE_URL */ @Deprecated
     AttributeSensor<String> MYSQL_URL = DATASTORE_URL;
 

--- a/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlNodeImpl.java
+++ b/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlNodeImpl.java
@@ -43,6 +43,12 @@ public class MySqlNodeImpl extends SoftwareProcessImpl implements MySqlNode {
 
     private static final Logger LOG = LoggerFactory.getLogger(MySqlNodeImpl.class);
 
+    /** This comes from mysql.cnf
+     * See http://dev.mysql.com/doc/refman/5.6/en/mysql-install-db.html and http://dev.mysql.com/doc/refman/5.7/en/mysql-install-db.html
+     * for more details.
+     * */
+    String DEFAULT_USERNAME = "root";
+
     private SshFeed feed;
 
     public MySqlNodeImpl() {
@@ -69,7 +75,7 @@ public class MySqlNodeImpl extends SoftwareProcessImpl implements MySqlNode {
     public MySqlDriver getDriver() {
         return (MySqlDriver) super.getDriver();
     }
-    
+
     @Override
     public void init() {
         super.init();
@@ -88,8 +94,8 @@ public class MySqlNodeImpl extends SoftwareProcessImpl implements MySqlNode {
     protected void connectSensors() {
         super.connectSensors();
         sensors().set(DATASTORE_URL, String.format("mysql://%s:%s/", getAttribute(HOSTNAME), getAttribute(MYSQL_PORT)));
-        
-        /*        
+        sensors().set(USER, getUser());
+        /*
          * TODO status gives us things like:
          *   Uptime: 2427  Threads: 1  Questions: 581  Slow queries: 0  Opens: 53  Flush tables: 1  Open tables: 35  Queries per second avg: 0.239
          * So can extract lots of sensors from that.
@@ -125,7 +131,7 @@ public class MySqlNodeImpl extends SoftwareProcessImpl implements MySqlNode {
             sensors().set(SERVICE_UP, true);
         }
     }
-    
+
     @Override
     protected void disconnectSensors() {
         if (feed != null) feed.stop();
@@ -145,6 +151,10 @@ public class MySqlNodeImpl extends SoftwareProcessImpl implements MySqlNode {
         return result;
     }
 
+    public String getUser() {
+        return DEFAULT_USERNAME;
+    }
+
     public String getPassword() {
         String result = getAttribute(MySqlNode.PASSWORD);
         if (Strings.isBlank(result)) {
@@ -153,7 +163,7 @@ public class MySqlNodeImpl extends SoftwareProcessImpl implements MySqlNode {
         }
         return result;
     }
-    
+
     @Override
     public String getShortName() {
         return "MySQL";


### PR DESCRIPTION
this sensor although static is useful for external services that need to remotely login to this db.
From mysql 5.7 seems possible to configure a different `admin-user` from `root`