### PR TITLE
BindDns improvements for CentOS

### DIFF
--- a/software/network/src/main/java/org/apache/brooklyn/entity/network/bind/BindDnsServerImpl.java
+++ b/software/network/src/main/java/org/apache/brooklyn/entity/network/bind/BindDnsServerImpl.java
@@ -105,6 +105,7 @@ public class BindDnsServerImpl extends SoftwareProcessImpl implements BindDnsSer
     public void init() {
         super.init();
         checkNotNull(getConfig(HOSTNAME_SENSOR), "%s requires value for %s", getClass().getName(), HOSTNAME_SENSOR);
+        checkNotNull(getConfig(ADDRESS_SENSOR), "%s requires value for %s", getClass().getName(), ADDRESS_SENSOR);
         DynamicGroup entities = addChild(EntitySpec.create(DynamicGroup.class)
                 .displayName("BIND-managed entities")
                 .configure(DynamicGroup.ENTITY_FILTER, getEntityFilter()));

--- a/software/network/src/main/java/org/apache/brooklyn/entity/network/bind/BindDnsServerSshDriver.java
+++ b/software/network/src/main/java/org/apache/brooklyn/entity/network/bind/BindDnsServerSshDriver.java
@@ -76,7 +76,7 @@ public class BindDnsServerSshDriver extends AbstractSoftwareProcessSshDriver imp
 
         List<String> commands = Lists.newArrayList(
                 BashCommands.sudo("mkdir -p " + getDataDirectory() + " " + getDynamicDirectory() + " " + getOsSupport().getConfigDirectory()),
-                BashCommands.sudo("chown -R bind:bind " + getDataDirectory() + " " + getDynamicDirectory()),
+                BashCommands.sudo("chown -R " + getOsSupport().getUser() + ":" + getOsSupport().getUser() + " " + getDataDirectory() + " " + getDynamicDirectory()),
                 // TODO determine name of ethernet interface if not eth0?
                 IptablesCommands.insertIptablesRule(Chain.INPUT, "eth0", Protocol.UDP, dnsPort, Policy.ACCEPT),
                 IptablesCommands.insertIptablesRule(Chain.INPUT, "eth0", Protocol.TCP, dnsPort, Policy.ACCEPT),

--- a/software/network/src/main/java/org/apache/brooklyn/entity/network/bind/BindOsSupport.java
+++ b/software/network/src/main/java/org/apache/brooklyn/entity/network/bind/BindOsSupport.java
@@ -62,7 +62,7 @@ public class BindOsSupport {
                 "named",
                 "/etc/named.conf",
                 "/var/named",
-                "/var/named/data",
+                "/var/named",
                 "/var/named/named.ca",
                 "/etc/named.iscdlv.key");
     }

--- a/software/network/src/main/java/org/apache/brooklyn/entity/network/bind/BindOsSupport.java
+++ b/software/network/src/main/java/org/apache/brooklyn/entity/network/bind/BindOsSupport.java
@@ -30,6 +30,7 @@ public class BindOsSupport {
     // Likewise would make these package-private and have no getters if Freemarker was ok with it.
     private final String packageName;
     private final String serviceName;
+    private final String user;
     private final String rootConfigFile;
     private final String configDirectory;
     private final String workingDirectory;
@@ -39,6 +40,7 @@ public class BindOsSupport {
     private BindOsSupport(
             String packageName,
             String serviceName,
+            String user,
             String rootConfigFile,
             String configDirectory,
             String workingDirectory,
@@ -46,6 +48,7 @@ public class BindOsSupport {
             String keysFile) {
         this.packageName = packageName;
         this.serviceName = serviceName;
+        this.user = user;
         this.rootConfigFile = rootConfigFile;
         this.configDirectory = configDirectory;
         this.workingDirectory = workingDirectory;
@@ -59,6 +62,7 @@ public class BindOsSupport {
     public static BindOsSupport forRhel() {
         return new BindOsSupport(
                 "bind",
+                "named",
                 "named",
                 "/etc/named.conf",
                 "/var/named",
@@ -74,6 +78,7 @@ public class BindOsSupport {
         return new BindOsSupport(
                 "bind9",
                 "bind9",
+                "bind",
                 "/etc/bind/named.conf",
                 "/etc/bind",
                 "/var/cache/bind",
@@ -110,4 +115,7 @@ public class BindOsSupport {
         return keysFile;
     }
 
+    public String getUser() {
+        return user;
+    }
 }


### PR DESCRIPTION
On CentOS bind is run by `named`, on Debian it is `bind`. Previously we used the latter in both cases.