### PR TITLE
Update default Zookeeper version and fix NPE

### DIFF
--- a/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperNode.java
+++ b/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperNode.java
@@ -38,7 +38,7 @@ import org.apache.brooklyn.util.core.flags.SetFromFlag;
 public interface ZooKeeperNode extends SoftwareProcess {
 
     @SetFromFlag("version")
-    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "3.4.5");
+    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "3.4.9");
 
     @SetFromFlag("archiveNameFormat")
     ConfigKey<String> ARCHIVE_DIRECTORY_NAME_FORMAT = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.ARCHIVE_DIRECTORY_NAME_FORMAT, "zookeeper-%s");

--- a/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperNodeImpl.java
+++ b/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperNodeImpl.java
@@ -30,4 +30,9 @@ public class ZooKeeperNodeImpl extends AbstractZooKeeperImpl implements ZooKeepe
         return ZooKeeperDriver.class;
     }
 
+    @Override
+    public void init() {
+        super.init();
+        sensors().set(ZooKeeperNode.MY_ID, 1);
+    }
 }

--- a/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperSshDriver.java
+++ b/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperSshDriver.java
@@ -62,17 +62,21 @@ public class ZooKeeperSshDriver extends JavaSoftwareProcessSshDriver implements 
     // Need a way to terminate the wait based on the entity going on-fire etc.
     // FIXME Race in getMemebers. Should we change DynamicCluster.grow to create the members and only then call start on them all?
     public List<ZooKeeperServerConfig> getZookeeperServers() throws ExecutionException, InterruptedException {
-        ZooKeeperEnsemble ensemble = (ZooKeeperEnsemble) entity.getParent();
         List<ZooKeeperServerConfig> result = Lists.newArrayList();
 
-        for (Entity member : ensemble.getMembers()) {
-            Integer myid = Entities.attributeSupplierWhenReady(member, ZooKeeperNode.MY_ID).get();
-            String hostname = Entities.attributeSupplierWhenReady(member, ZooKeeperNode.HOSTNAME).get();
-            Integer port = Entities.attributeSupplierWhenReady(member, ZooKeeperNode.ZOOKEEPER_PORT).get();
-            Integer leaderPort = Entities.attributeSupplierWhenReady(member, ZooKeeperNode.ZOOKEEPER_LEADER_PORT).get();
-            Integer electionPort = Entities.attributeSupplierWhenReady(member, ZooKeeperNode.ZOOKEEPER_ELECTION_PORT).get();
-            result.add(new ZooKeeperServerConfig(myid, hostname, port, leaderPort, electionPort));
+        if (entity.getParent().getClass().isAssignableFrom(ZooKeeperEnsemble.class)) {
+            ZooKeeperEnsemble ensemble = (ZooKeeperEnsemble) entity.getParent();
+
+            for (Entity member : ensemble.getMembers()) {
+                Integer myid = Entities.attributeSupplierWhenReady(member, ZooKeeperNode.MY_ID).get();
+                String hostname = Entities.attributeSupplierWhenReady(member, ZooKeeperNode.HOSTNAME).get();
+                Integer port = Entities.attributeSupplierWhenReady(member, ZooKeeperNode.ZOOKEEPER_PORT).get();
+                Integer leaderPort = Entities.attributeSupplierWhenReady(member, ZooKeeperNode.ZOOKEEPER_LEADER_PORT).get();
+                Integer electionPort = Entities.attributeSupplierWhenReady(member, ZooKeeperNode.ZOOKEEPER_ELECTION_PORT).get();
+                result.add(new ZooKeeperServerConfig(myid, hostname, port, leaderPort, electionPort));
+            }
         }
+
         return result;
     }
 


### PR DESCRIPTION
This updates the Zookeeper version to use (version 3.4.5 not available anymore).
It also fixes a NPE on customize phase, caused by:
- the `ZookeeperNode.MY_ID` not set for a single `ZookeeperNode`
- getZookeeperServers() expecting the parent to be and entity of type `ZookeeperEnsemble`, which is not the case for a single `ZookeeperNode`
