### PR TITLE
Fix test to work on any combination of OS & eol type.

### DIFF
--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/dns/geoscaling/GeoscalingScriptGenerator.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/dns/geoscaling/GeoscalingScriptGenerator.java
@@ -54,18 +54,18 @@ public class GeoscalingScriptGenerator {
     
     private static String getHostsDeclaration(Collection<HostGeoInfo> hosts) {
         StringBuffer sb = new StringBuffer();
-        sb.append("$hosts = array(").append(Os.LINE_SEPARATOR);
+        sb.append("$hosts = array(\n");
         Iterator<HostGeoInfo> iServer = hosts.iterator();
         while (iServer.hasNext()) {
             HostGeoInfo server = iServer.next();
-            sb.append("    array('name'      => '").append(escape(server.displayName)).append("',").append(Os.LINE_SEPARATOR);
-            sb.append("          'latitude'  => ").append(server.latitude).append(",").append(Os.LINE_SEPARATOR);
-            sb.append("          'longitude' => ").append(server.longitude).append(",").append(Os.LINE_SEPARATOR);
+            sb.append("    array('name'      => '").append(escape(server.displayName)).append("',\n");
+            sb.append("          'latitude'  => ").append(server.latitude).append(",\n");
+            sb.append("          'longitude' => ").append(server.longitude).append(",\n");
             sb.append("          'ip'        => '").append(escape(server.address)).append("')");
-            if (iServer.hasNext()) sb.append(",").append(Os.LINE_SEPARATOR);
-            sb.append(Os.LINE_SEPARATOR);
+            if (iServer.hasNext()) sb.append(",\n");
+            sb.append("\n");
         }
-        sb.append(");").append(Os.LINE_SEPARATOR);
+        sb.append(");").append("\n");
         return sb.toString();
     }
     

--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/dns/geoscaling/GeoscalingScriptGeneratorTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/dns/geoscaling/GeoscalingScriptGeneratorTest.java
@@ -48,10 +48,22 @@ public class GeoscalingScriptGeneratorTest {
         String generatedScript = GeoscalingScriptGenerator.generateScriptString(generationTime, HOSTS);
         assertTrue(generatedScript.contains("1.2.3"));
         String expectedScript = ResourceUtils.create(this).getResourceAsString("org/apache/brooklyn/entity/dns/geoscaling/expectedScript.php");
-        assertEquals(generatedScript, expectedScript);
+        assertEqualsNormalizedEol(generatedScript, expectedScript);
         //also make sure leading slash is allowed
         String expectedScript2 = ResourceUtils.create(this).getResourceAsString("org/apache/brooklyn/entity/dns/geoscaling/expectedScript.php");
-        assertEquals(generatedScript, expectedScript);
+        assertEqualsNormalizedEol(generatedScript, expectedScript2);
     }
-    
+
+
+    private void assertEqualsNormalizedEol(String generatedScript, String expectedScript) {
+        assertEquals(normalizeEol(generatedScript), normalizeEol(expectedScript));
+    }
+
+
+    private Object normalizeEol(String str) {
+        // Remove CR in case the files are checked out on Windows.
+        // That's just to satisfy the test condition, PHP doesn't care about line endings.
+        return str.replace("\r\n", "\n");
+    }
+
 }


### PR DESCRIPTION
Change line endings for generated script as it's most likely to run in a unix environment.
Normalize line endings when comparing scripts to work with any combination of OS & line endings (for tests running on Windows mostly). On Windows you can have both CRLF or LF line endings in the files (or even mixed), depending on how git is configured. That's out of our control so try to support any environment.

The recommended confgiuration is "git --global core.autocrlf true", but Apache Jenkins machines have "core.autocrlf" set to "input". The former will lead to CRLF line endings, the latter to LF line endings on checkout.