### PR TITLE
Set default JVM memory settings for the build

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,1 @@
+-Xmx1024m -Xms512m -XX:MaxPermSize=256m


### PR DESCRIPTION
* Will be picked up when building a sub-module
* Doesn't work with `--file` option ([MNG-5889](https://issues.apache.org/jira/browse/MNG-5889))