### PR TITLE
ZooKeeper ensemble fixes

### DIFF
--- a/software/messaging/pom.xml
+++ b/software/messaging/pom.xml
@@ -219,6 +219,10 @@
                     <groupId>storm</groupId>
                     <artifactId>carbonite</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 

--- a/software/messaging/pom.xml
+++ b/software/messaging/pom.xml
@@ -222,6 +222,15 @@
             </exclusions>
         </dependency>
 
+        <dependency>
+            <!-- We exclude jsr311-api transitive dependency from jclouds (for javax.ws.rs) due to version conflict.
+                 Therefore explicitly bring this one in.
+            -->
+            <groupId>javax.ws.rs</groupId>
+            <artifactId>javax.ws.rs-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Transitive dependencies, declared explicitly due to version mismatch -->
         <dependency>
             <groupId>log4j</groupId>

--- a/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/AbstractZooKeeperImpl.java
+++ b/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/AbstractZooKeeperImpl.java
@@ -94,9 +94,9 @@ public abstract class AbstractZooKeeperImpl extends SoftwareProcessImpl implemen
 
     @Override
     public void disconnectSensors() {
-        super.disconnectSensors();
-        disconnectServiceUpIsRunning();
         if (jmxFeed != null) jmxFeed.stop();
+        disconnectServiceUpIsRunning();
+        super.disconnectSensors();
     }
 
     @Override

--- a/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperEnsemble.java
+++ b/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperEnsemble.java
@@ -54,9 +54,11 @@ public interface ZooKeeperEnsemble extends DynamicCluster {
             .constraint(Predicates.notNull())
             .build();
 
-    @SuppressWarnings("serial")
     AttributeSensor<List<String>> ZOOKEEPER_SERVERS = Sensors.newSensor(new TypeToken<List<String>>() { },
             "zookeeper.servers", "Hostnames to connect to cluster with");
+
+    AttributeSensor<String> ZOOKEEPER_ENDPOINTS = Sensors.newStringSensor(
+            "zookeeper.endpoints", "A comma-separated host:port list of members of the ensemble");
 
     /** @deprecated since 0.10.0 use <code>sensors().get(ZooKeeperEnsemble.CLUSTER_NAME)</code> instead */
     @Deprecated

--- a/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperEnsemble.java
+++ b/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperEnsemble.java
@@ -29,7 +29,10 @@ import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.entity.group.DynamicCluster;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
+import org.apache.brooklyn.util.guava.Suppliers;
 
+import com.google.common.base.Predicates;
+import com.google.common.base.Supplier;
 import com.google.common.reflect.TypeToken;
 
 @Catalog(name="ZooKeeper ensemble", description="A cluster of ZooKeeper servers. "
@@ -38,15 +41,24 @@ import com.google.common.reflect.TypeToken;
 public interface ZooKeeperEnsemble extends DynamicCluster {
 
     @SetFromFlag("clusterName")
-    BasicAttributeSensorAndConfigKey<String> CLUSTER_NAME = new BasicAttributeSensorAndConfigKey<String>(String
-            .class, "zookeeper.cluster.name", "Name of the Zookeeper cluster", "BrooklynZookeeperCluster");
+    BasicAttributeSensorAndConfigKey<String> CLUSTER_NAME = new BasicAttributeSensorAndConfigKey<String>(String.class,
+            "zookeeper.cluster.name", "Name of the Zookeeper cluster", "BrooklynZookeeperCluster");
 
     @SetFromFlag("initialSize")
-    public static final ConfigKey<Integer> INITIAL_SIZE = ConfigKeys.newConfigKeyWithDefault(DynamicCluster.INITIAL_SIZE, 3);
+    ConfigKey<Integer> INITIAL_SIZE = ConfigKeys.newConfigKeyWithDefault(DynamicCluster.INITIAL_SIZE, 3);
+
+    ConfigKey<Supplier<Integer>> NODE_ID_SUPPLIER = ConfigKeys.builder(new TypeToken<Supplier<Integer>>() {})
+            .name("zookeeper.nodeId.supplier")
+            .description("Supplies values for members id in zoo.cfg")
+            .defaultValue(Suppliers.incrementing())
+            .constraint(Predicates.notNull())
+            .build();
 
     @SuppressWarnings("serial")
     AttributeSensor<List<String>> ZOOKEEPER_SERVERS = Sensors.newSensor(new TypeToken<List<String>>() { },
             "zookeeper.servers", "Hostnames to connect to cluster with");
 
+    /** @deprecated since 0.10.0 use <code>sensors().get(ZooKeeperEnsemble.CLUSTER_NAME)</code> instead */
+    @Deprecated
     String getClusterName();
 }

--- a/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperEnsembleImpl.java
+++ b/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperEnsembleImpl.java
@@ -20,69 +20,39 @@ package org.apache.brooklyn.entity.zookeeper;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.entity.EntitySpec;
 import org.apache.brooklyn.api.location.Location;
-import org.apache.brooklyn.api.policy.PolicySpec;
 import org.apache.brooklyn.core.entity.Attributes;
-import org.apache.brooklyn.core.entity.EntityInternal;
 import org.apache.brooklyn.entity.group.AbstractMembershipTrackingPolicy;
 import org.apache.brooklyn.entity.group.DynamicClusterImpl;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.apache.brooklyn.util.guava.Suppliers;
+
+import com.google.common.base.Supplier;
 
 import com.google.common.collect.Lists;
 
 public class ZooKeeperEnsembleImpl extends DynamicClusterImpl implements ZooKeeperEnsemble {
 
-    private static final Logger log = LoggerFactory.getLogger(ZooKeeperEnsembleImpl.class);
-    private static final AtomicInteger myId = new AtomicInteger();
-    
-    private MemberTrackingPolicy policy;
-
     public ZooKeeperEnsembleImpl() {}
 
     /**
      * Sets the default {@link #MEMBER_SPEC} to describe the ZooKeeper nodes.
+     * Overwrites any value configured for {@link ZooKeeperNode#MY_ID} to use
+     * the value given by {@link ZooKeeperEnsemble#NODE_ID_SUPPLIER}.
      */
     @Override
     protected EntitySpec<?> getMemberSpec() {
-        return getConfig(MEMBER_SPEC, EntitySpec.create(ZooKeeperNode.class));
+        EntitySpec<?> spec = getConfig(MEMBER_SPEC, EntitySpec.create(ZooKeeperNode.class));
+        spec.configure(ZooKeeperNode.MY_ID, config().get(ZooKeeperEnsemble.NODE_ID_SUPPLIER).get());
+        return spec;
     }
 
     @Override
     public String getClusterName() {
         return getAttribute(CLUSTER_NAME);
     }
-
-    @Override
-    public void init() {
-        log.info("Initializing the ZooKeeper Ensemble");
-        super.init();
-
-        policy = policies().add(PolicySpec.create(MemberTrackingPolicy.class)
-                .displayName("Members tracker")
-                .configure("group", this));
-    }
-
-    public static class MemberTrackingPolicy extends AbstractMembershipTrackingPolicy {
-        @Override
-        protected void onEntityChange(Entity member) {
-        }
-
-        @Override
-        protected void onEntityAdded(Entity member) {
-            if (member.getAttribute(ZooKeeperNode.MY_ID) == null) {
-                ((EntityInternal) member).sensors().set(ZooKeeperNode.MY_ID, myId.incrementAndGet());
-            }
-        }
-
-        @Override
-        protected void onEntityRemoved(Entity member) {
-        }
-    };
 
     @Override
     protected void initEnrichers() {
@@ -99,6 +69,33 @@ public class ZooKeeperEnsembleImpl extends DynamicClusterImpl implements ZooKeep
             zookeeperServers.add(zookeeper.getAttribute(Attributes.HOSTNAME));
         }
         sensors().set(ZOOKEEPER_SERVERS, zookeeperServers);
+    }
+
+    /**
+     * @deprecated since 0.10.0 class is unused but kept for persistence backwards compatibility
+     */
+    @Deprecated
+    private static class MemberTrackingPolicy extends AbstractMembershipTrackingPolicy {
+        private final Object[] mutex = new Object[0];
+
+        @Override
+        protected void onEntityAdded(Entity member) {
+            if (member.config().get(ZooKeeperNode.MY_ID) == null) {
+                Supplier<Integer> id;
+                synchronized (mutex) {
+                    // Entities may not have been created with NODE_ID_SUPPLIER, so create it if
+                    // it's not there. We can't provide any good guarantees about what number to
+                    // start with, but then again the previous version of the entity gave no
+                    // guarantee either.
+                    id = entity.config().get(ZooKeeperEnsemble.NODE_ID_SUPPLIER);
+                    if (id == null) {
+                        id = Suppliers.incrementing();
+                        entity.config().set(ZooKeeperEnsemble.NODE_ID_SUPPLIER, id);
+                    }
+                }
+                member.config().set(ZooKeeperNode.MY_ID, id.get());
+            }
+        }
     }
 
 }

--- a/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperNode.java
+++ b/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperNode.java
@@ -24,6 +24,7 @@ import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.config.ConfigKeys;
 import org.apache.brooklyn.core.sensor.AttributeSensorAndConfigKey;
+import org.apache.brooklyn.core.sensor.BasicAttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.PortAttributeSensorAndConfigKey;
 import org.apache.brooklyn.core.sensor.Sensors;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
@@ -64,12 +65,19 @@ public interface ZooKeeperNode extends SoftwareProcess {
             "zookeeper.configTemplate", "Zookeeper configuration template (in freemarker format)",
             "classpath://org/apache/brooklyn/entity/messaging/zookeeper/zoo.cfg");
 
+    @SetFromFlag("zookeeperId")
+    BasicAttributeSensorAndConfigKey<Integer> MY_ID = new BasicAttributeSensorAndConfigKey<>(Integer.class,
+            "zookeeper.myid", "ZooKeeper node's myId", 1);
+
     AttributeSensor<Long> OUTSTANDING_REQUESTS = Sensors.newLongSensor("zookeeper.outstandingRequests", "Outstanding request count");
     AttributeSensor<Long> PACKETS_RECEIVED = Sensors.newLongSensor("zookeeper.packets.received", "Total packets received");
     AttributeSensor<Long> PACKETS_SENT = Sensors.newLongSensor("zookeeper.packets.sent", "Total packets sent");
-    AttributeSensor<Integer> MY_ID = Sensors.newIntegerSensor("zookeeper.myid", "ZooKeeper node's myId");
 
+    /** @deprecated since 0.10.0 use <code>sensors().get(ZooKeeperNode.ZOOKEEPER_PORT)</code> instead */
+    @Deprecated
     Integer getZookeeperPort();
 
+    /** @deprecated since 0.10.0 use <code>sensors().get(ZooKeeperNode.HOSTNAME)</code> instead */
+    @Deprecated
     String getHostname();
 }

--- a/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperNodeImpl.java
+++ b/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperNodeImpl.java
@@ -18,6 +18,13 @@
  */
 package org.apache.brooklyn.entity.zookeeper;
 
+import java.net.URI;
+
+import org.apache.brooklyn.core.entity.Attributes;
+import org.apache.brooklyn.core.location.access.BrooklynAccessUtils;
+
+import com.google.common.net.HostAndPort;
+
 /**
  * An {@link org.apache.brooklyn.api.entity.Entity} that represents a single standalone zookeeper instance.
  */
@@ -42,4 +49,10 @@ public class ZooKeeperNodeImpl extends AbstractZooKeeperImpl implements ZooKeepe
         return ZooKeeperDriver.class;
     }
 
+    @Override
+    protected void postStart() {
+        super.postStart();
+        HostAndPort hap = BrooklynAccessUtils.getBrooklynAccessibleAddress(this, sensors().get(ZOOKEEPER_PORT));
+        sensors().set(Attributes.MAIN_URI, URI.create(hap.toString()));
+    }
 }

--- a/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperNodeImpl.java
+++ b/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperNodeImpl.java
@@ -26,13 +26,20 @@ public class ZooKeeperNodeImpl extends AbstractZooKeeperImpl implements ZooKeepe
     public ZooKeeperNodeImpl() {}
 
     @Override
+    public void init() {
+        super.init();
+        // MY_ID was changed from a sensor to config. Publish it as a sensor to maintain
+        // compatibility with any blueprints that reference it.
+        Integer myId = config().get(MY_ID);
+        if (myId == null) {
+            throw new NullPointerException("Require value for " + MY_ID.getName());
+        }
+        sensors().set(MY_ID, myId);
+    }
+
+    @Override
     public Class<?> getDriverInterface() {
         return ZooKeeperDriver.class;
     }
 
-    @Override
-    public void init() {
-        super.init();
-        sensors().set(ZooKeeperNode.MY_ID, 1);
-    }
 }

--- a/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/zookeeper/ZooKeeperEnsembleLiveTest.java
+++ b/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/zookeeper/ZooKeeperEnsembleLiveTest.java
@@ -98,6 +98,8 @@ public class ZooKeeperEnsembleLiveTest extends BrooklynAppLiveTestSupport {
 
         EntityAsserts.assertAttributeEqualsEventually(ensemble, ZooKeeperEnsemble.GROUP_SIZE, 3);
         EntityAsserts.assertAttributeEqualsEventually(ensemble, Startable.SERVICE_UP, true);
+        assertNotNull(ensemble.sensors().get(ZooKeeperEnsemble.ZOOKEEPER_ENDPOINTS),
+                "expected value for " + ZooKeeperEnsemble.ZOOKEEPER_ENDPOINTS + " on " + ensemble + ", was null");
         Set<Integer> nodeIds = Sets.newHashSet();
         for (Entity zkNode : ensemble.getMembers()) {
             nodeIds.add(zkNode.config().get(ZooKeeperNode.MY_ID));

--- a/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/zookeeper/ZooKeeperTestSupport.java
+++ b/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/zookeeper/ZooKeeperTestSupport.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.brooklyn.entity.messaging.zookeeper;
+
+import java.io.Closeable;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.brooklyn.util.exceptions.Exceptions;
+import org.apache.zookeeper.CreateMode;
+import org.apache.zookeeper.WatchedEvent;
+import org.apache.zookeeper.Watcher;
+import org.apache.zookeeper.ZooDefs;
+import org.apache.zookeeper.ZooKeeper;
+import org.apache.zookeeper.data.Stat;
+
+import com.google.common.net.HostAndPort;
+
+/**
+ * Useful methods for writing to and reading from ZooKeeper nodes.
+ */
+public class ZooKeeperTestSupport implements Closeable {
+
+    private final ZooKeeper zk;
+    private final CountDownLatch connSignal = new CountDownLatch(1);
+
+    public ZooKeeperTestSupport(HostAndPort hostAndPort) throws Exception {
+        final int sessionTimeout = 3000;
+        zk = new ZooKeeper(hostAndPort.toString(), sessionTimeout, new Watcher() {
+            @Override
+            public void process(WatchedEvent event) {
+                if (event.getState() == Event.KeeperState.SyncConnected) {
+                    connSignal.countDown();
+                }
+            }
+        });
+        connSignal.await();
+    }
+
+    @Override
+    public void close() {
+        try {
+            zk.close();
+        } catch (InterruptedException e) {
+            throw Exceptions.propagate(e);
+        }
+    }
+
+    public String create(String path, byte[] data) throws Exception {
+        return zk.create(path, data, ZooDefs.Ids.OPEN_ACL_UNSAFE, CreateMode.PERSISTENT);
+    }
+
+    public Stat update(String path, byte[] data) throws Exception {
+        return zk.setData(path, data, zk.exists(path, true).getVersion());
+    }
+
+    public void delete(String path) throws Exception {
+        zk.delete(path, zk.exists(path, true).getVersion());
+    }
+
+    public byte[] get(String path) throws Exception {
+        return zk.getData(path, false, zk.exists(path, false));
+    }
+
+}

--- a/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/zookeeper/ZooKeeperTestSupport.java
+++ b/software/messaging/src/test/java/org/apache/brooklyn/entity/messaging/zookeeper/ZooKeeperTestSupport.java
@@ -22,6 +22,7 @@ package org.apache.brooklyn.entity.messaging.zookeeper;
 import java.io.Closeable;
 import java.util.concurrent.CountDownLatch;
 
+import org.apache.brooklyn.location.paas.PaasLocation;
 import org.apache.brooklyn.util.exceptions.Exceptions;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.WatchedEvent;
@@ -29,6 +30,8 @@ import org.apache.zookeeper.Watcher;
 import org.apache.zookeeper.ZooDefs;
 import org.apache.zookeeper.ZooKeeper;
 import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.net.HostAndPort;
 
@@ -37,16 +40,20 @@ import com.google.common.net.HostAndPort;
  */
 public class ZooKeeperTestSupport implements Closeable {
 
+    private static final Logger LOG = LoggerFactory.getLogger(ZooKeeperTestSupport.class);
     private final ZooKeeper zk;
     private final CountDownLatch connSignal = new CountDownLatch(1);
 
-    public ZooKeeperTestSupport(HostAndPort hostAndPort) throws Exception {
+    public ZooKeeperTestSupport(final HostAndPort hostAndPort) throws Exception {
         final int sessionTimeout = 3000;
         zk = new ZooKeeper(hostAndPort.toString(), sessionTimeout, new Watcher() {
             @Override
             public void process(WatchedEvent event) {
                 if (event.getState() == Event.KeeperState.SyncConnected) {
+                    LOG.debug("Connected to ZooKeeper at {}", hostAndPort);
                     connSignal.countDown();
+                } else {
+                    LOG.info("WatchedEvent at {}: {}", hostAndPort, event.getState());
                 }
             }
         });


### PR DESCRIPTION
* Fixes ZooKeeper ensembles by ensuring that each node has a different id. 
* Improves live tests to test that data can be written and read back.
* ZooKeeperNodes publish their host and port on main.uri
* ZooKeeperEnsemble aggregates its member's main.uris into a list and combines them into a comma-separated string at `zookeeper.endpoints`.