### PR TITLE
Tweak to password change effector so that sed identifier is escaped

### DIFF
--- a/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlNodeEffectors.java
+++ b/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlNodeEffectors.java
@@ -75,7 +75,7 @@ public class MySqlNodeEffectors {
             DynamicTasks.queue(
                     SshTasks.newSshExecTaskFactory(machine, 
                                     "cd "+entity().getAttribute(MySqlNode.RUN_DIR),
-                                    "sed -i'' -e 's@^\\(\\s*password\\s*=\\s*\\).*$@\\1" + newPass.replace("\\", "\\\\") + "@g' mymysql.cnf")
+                                    "sed -i'' -e 's/^\\(\\s*password\\s*=\\s*\\).*$/\\1" + newPass.replace("\\", "\\\\").replace("/","\\/") + "/g' mymysql.cnf")
                             .requiringExitCodeZero()
                             .summary("Change root password"));
             return null;


### PR DESCRIPTION
*Previously*
`s@<regex>@<replace>@g` would not work for a password with an `@`
*Now*
`s/<regex>/<replace>/g` `/` values are escaped in the replace value