### PR TITLE
Zookeeper node main URI must contain a protocol

### DIFF
--- a/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperNodeImpl.java
+++ b/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperNodeImpl.java
@@ -53,6 +53,6 @@ public class ZooKeeperNodeImpl extends AbstractZooKeeperImpl implements ZooKeepe
     protected void postStart() {
         super.postStart();
         HostAndPort hap = BrooklynAccessUtils.getBrooklynAccessibleAddress(this, sensors().get(ZOOKEEPER_PORT));
-        sensors().set(Attributes.MAIN_URI, URI.create(hap.toString()));
+        sensors().set(Attributes.MAIN_URI, URI.create("zk://" +hap.toString()));
     }
 }


### PR DESCRIPTION
Zookeeper node fails as a `URISyntaxException` is thrown during creation of the main uri


