### PR TITLE
Publish ZooKeeperNode host+port at ZOOKEEPER_ENDPOINT

### DIFF
--- a/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperEnsembleImpl.java
+++ b/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperEnsembleImpl.java
@@ -54,7 +54,7 @@ public class ZooKeeperEnsembleImpl extends DynamicClusterImpl implements ZooKeep
     protected void initEnrichers() {
         super.initEnrichers();
         EnricherSpec<?> zks = Enrichers.builder()
-                .aggregating(Attributes.MAIN_URI)
+                .aggregating(ZooKeeperNode.ZOOKEEPER_ENDPOINT)
                 .publishing(ZOOKEEPER_SERVERS)
                 .fromMembers()
                 .build();

--- a/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperNode.java
+++ b/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperNode.java
@@ -73,6 +73,9 @@ public interface ZooKeeperNode extends SoftwareProcess {
     AttributeSensor<Long> PACKETS_RECEIVED = Sensors.newLongSensor("zookeeper.packets.received", "Total packets received");
     AttributeSensor<Long> PACKETS_SENT = Sensors.newLongSensor("zookeeper.packets.sent", "Total packets sent");
 
+    AttributeSensor<String> ZOOKEEPER_ENDPOINT = Sensors.newStringSensor(
+            "zookeeper.endpoint", "The host:port of the node");
+
     /** @deprecated since 0.10.0 use <code>sensors().get(ZooKeeperNode.ZOOKEEPER_PORT)</code> instead */
     @Deprecated
     Integer getZookeeperPort();

--- a/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperNodeImpl.java
+++ b/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperNodeImpl.java
@@ -53,6 +53,7 @@ public class ZooKeeperNodeImpl extends AbstractZooKeeperImpl implements ZooKeepe
     protected void postStart() {
         super.postStart();
         HostAndPort hap = BrooklynAccessUtils.getBrooklynAccessibleAddress(this, sensors().get(ZOOKEEPER_PORT));
+        sensors().set(ZooKeeperNode.ZOOKEEPER_ENDPOINT, hap.toString());
         sensors().set(Attributes.MAIN_URI, URI.create("zk://" +hap.toString()));
     }
 }


### PR DESCRIPTION
Fixes `ZooKeeperEnsemble.ZOOKEEPER_ENDPOINTS` and by extension `ZooKeeperEnsembleLiveTest` after the changes in https://github.com/apache/brooklyn-library/pull/78.