### PR TITLE
Update MariaDB default version

### DIFF
--- a/software/database/src/main/java/org/apache/brooklyn/entity/database/mariadb/MariaDbNode.java
+++ b/software/database/src/main/java/org/apache/brooklyn/entity/database/mariadb/MariaDbNode.java
@@ -42,7 +42,7 @@ public interface MariaDbNode extends SoftwareProcess, DatastoreCommon, HasShortN
 
     @SetFromFlag("version")
     public static final ConfigKey<String> SUGGESTED_VERSION =
-        ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "5.5.40");
+        ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "5.5.53");
 
     // https://downloads.mariadb.org/interstitial/mariadb-5.5.33a/kvm-bintar-hardy-amd64/mariadb-5.5.33a-linux-x86_64.tar.gz/from/http://mirrors.coreix.net/mariadb
     // above redirects to download the artifactd from the URLs below.
@@ -57,7 +57,7 @@ public interface MariaDbNode extends SoftwareProcess, DatastoreCommon, HasShortN
     /** download mirror, if desired */
     @SetFromFlag("mirrorUrl")
     public static final ConfigKey<String> MIRROR_URL = ConfigKeys.newStringConfigKey("mariadb.install.mirror.url", "URL of mirror",
-        "http://mirrors.coreix.net/mariadb/"
+        "http://mirrors.coreix.net/mariadb"
      );
 
     @SetFromFlag("port")


### PR DESCRIPTION
On the latest CentOS 7.2.x MariaDB application fails to start.
This is fixed with the latest MariaDB 5.5.53 so upgrading to it.

Longer term I think it is better if the blueprint is changed to use the yum mariadb repository and to retrieve an rpm from there.


