### PR TITLE
Upgrade karaf-maven-plugin to avoid double User-Agent bug

### DIFF
--- a/karaf/features/pom.xml
+++ b/karaf/features/pom.xml
@@ -38,7 +38,7 @@
                 <plugin>
                     <groupId>org.apache.karaf.tooling</groupId>
                     <artifactId>karaf-maven-plugin</artifactId>
-                    <version>4.0.1</version>
+                    <version>${karaf.plugin.version}</version>
                     <extensions>true</extensions>
                 </plugin>
             </plugins>


### PR DESCRIPTION
Depends on https://github.com/apache/brooklyn-server/pull/479. See it for a detailed description.