### PR TITLE
Remove YAML tags from CM output

### DIFF
--- a/software/cm/salt/src/main/java/org/apache/brooklyn/entity/cm/salt/impl/SaltHighstate.java
+++ b/software/cm/salt/src/main/java/org/apache/brooklyn/entity/cm/salt/impl/SaltHighstate.java
@@ -73,7 +73,7 @@ public class SaltHighstate {
 
 
     private static String adaptForSaltYamlTypes(String description) {
-        return description.replaceAll("!!python/unicode", "!!java.lang.String");
+        return description.replaceAll("!!python/unicode\\s+", "");
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
What "adaptForSaltYamlTypes" does is pass a string to the "java.lang.String" constructor. No point in that, use the argument string directly.