### PR TITLE
Updates zookeeper download URL

### DIFF
--- a/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperNode.java
+++ b/software/messaging/src/main/java/org/apache/brooklyn/entity/zookeeper/ZooKeeperNode.java
@@ -46,7 +46,7 @@ public interface ZooKeeperNode extends SoftwareProcess {
 
     @SetFromFlag("downloadUrl")
     AttributeSensorAndConfigKey<String, String> DOWNLOAD_URL = ConfigKeys.newSensorAndConfigKeyWithDefault(SoftwareProcess.DOWNLOAD_URL,
-            "http://apache.fastbull.org/zookeeper/zookeeper-${version}/zookeeper-${version}.tar.gz");
+            "http://apache.org/dyn/closer.cgi?filename=zookeeper/zookeeper-${version}/zookeeper-${version}.tar.gz&action=download");
 
     @SetFromFlag("zookeeperPort")
     PortAttributeSensorAndConfigKey ZOOKEEPER_PORT = ConfigKeys.newPortSensorAndConfigKey("zookeeper.port", "Zookeeper port", "2181+");


### PR DESCRIPTION
Fastbull is not longer a valid download URL for zookeeper ... changed to apache hosted