### PR TITLE
Fix executeScript effector for MariaDB and PostreSQL

### DIFF
--- a/software/database/src/main/java/org/apache/brooklyn/entity/database/mariadb/MariaDbSshDriver.java
+++ b/software/database/src/main/java/org/apache/brooklyn/entity/database/mariadb/MariaDbSshDriver.java
@@ -252,6 +252,7 @@ public class MariaDbSshDriver extends AbstractSoftwareProcessSshDriver implement
                 SshEffectorTasks.ssh(
                                 "cd "+getRunDir(),
                                 getBaseDir()+"/bin/mysql --defaults-file="+getConfigFile()+" < "+filenameAlreadyInstalledAtServer)
+                        .requiringExitCodeZero()
                         .summary("executing datastore script "+filenameAlreadyInstalledAtServer));
     }
 

--- a/software/database/src/main/java/org/apache/brooklyn/entity/database/postgresql/PostgreSqlSshDriver.java
+++ b/software/database/src/main/java/org/apache/brooklyn/entity/database/postgresql/PostgreSqlSshDriver.java
@@ -570,7 +570,8 @@ public class PostgreSqlSshDriver extends AbstractSoftwareProcessSshDriver implem
         return DynamicTasks.queue(
             SshEffectorTasks.ssh(
                 "cd "+getRunDir(),
-                sudoAsUser("postgres", getInstallDir() + "/bin/psql -p " + entity.getAttribute(PostgreSqlNode.POSTGRESQL_PORT) + " --file " + filenameAlreadyInstalledAtServer))
+                sudoAsUser("postgres", getInstallDir() + "/bin/psql -p " + entity.getAttribute(PostgreSqlNode.POSTGRESQL_PORT) + " -v ON_ERROR_STOP=1 --file " + filenameAlreadyInstalledAtServer))
+                    .requiringExitCodeZero()
                 .summary("executing datastore script "+filenameAlreadyInstalledAtServer));
     }
 


### PR DESCRIPTION
Fixes executeScript effector to fail on wrong command.

For postresql the script was returning exit code 0 and required command modification.