### PR TITLE
Update random passwords

### DIFF
--- a/qa/src/test/java/org/apache/brooklyn/qa/brooklynnode/SoftlayerObtainPrivateLiveTest.java
+++ b/qa/src/test/java/org/apache/brooklyn/qa/brooklynnode/SoftlayerObtainPrivateLiveTest.java
@@ -44,6 +44,7 @@ import org.apache.brooklyn.util.collections.MutableList;
 import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.BrooklynMavenArtifacts;
 import org.apache.brooklyn.util.maven.MavenRetriever;
+import org.apache.brooklyn.util.text.Identifiers;
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.time.Duration;
 import org.slf4j.Logger;
@@ -124,7 +125,7 @@ public class SoftlayerObtainPrivateLiveTest {
     public void testObtain() {
         String localUrl = MavenRetriever.localUrl(BrooklynMavenArtifacts.artifact("", "brooklyn-dist", "tar.gz", "dist"));
         String userName = "admin";
-        String userPassword = Strings.makeRandomId(6);
+        String userPassword = Identifiers.makeRandomPassword(6);
         String remoteConfig = Joiner.on('\n').join(MutableList.of(
                 "brooklyn.webconsole.security.users=" + userName,
                 "brooklyn.webconsole.security.user.admin.password=" + userPassword)

--- a/software/database/src/main/java/org/apache/brooklyn/entity/database/postgresql/PostgreSqlSshDriver.java
+++ b/software/database/src/main/java/org/apache/brooklyn/entity/database/postgresql/PostgreSqlSshDriver.java
@@ -456,7 +456,7 @@ public class PostgreSqlSshDriver extends AbstractSoftwareProcessSshDriver implem
     }
     
     protected String getUserPassword() {
-        return getConfigOrDefault(PostgreSqlNode.PASSWORD, Strings.makeRandomId(8));
+        return getConfigOrDefault(PostgreSqlNode.PASSWORD, Identifiers.makeRandomPassword(8));
     }
 
     protected void executeDatabaseCreationScript() {

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/hazelcast/HazelcastClusterImpl.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/hazelcast/HazelcastClusterImpl.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.brooklyn.util.text.Identifiers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,7 +69,7 @@ public class HazelcastClusterImpl extends DynamicClusterImpl implements Hazelcas
             if (LOG.isInfoEnabled()) {
                 LOG.info(this + " cluster password not provided for " + CLUSTER_PASSWORD.getName() + " : generating random password");
             }
-            config().set(CLUSTER_PASSWORD, Strings.makeRandomId(12));
+            config().set(CLUSTER_PASSWORD, Identifiers.makeRandomPassword(12));
         }
         
         policies().add(PolicySpec.create(MemberTrackingPolicy.class)

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/mongodb/MongoDBAuthenticationUtils.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/mongodb/MongoDBAuthenticationUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.brooklyn.entity.nosql.mongodb;
 
+import org.apache.brooklyn.util.text.Identifiers;
 import org.apache.brooklyn.util.text.Strings;
 
 import org.apache.brooklyn.api.entity.EntitySpec;
@@ -46,7 +47,7 @@ public class MongoDBAuthenticationUtils {
         String password = entity.config().get(MongoDBAuthenticationMixins.ROOT_PASSWORD);
         if (Strings.isEmpty(password)) {
             LOG.debug(entity + " has no password specified for " + MongoDBAuthenticationMixins.ROOT_PASSWORD.getName() + "; using a random string");
-            password = Strings.makeRandomId(16);
+            password = Identifiers.makeRandomPassword(16);
             entity.sensors().set(MongoDBAuthenticationMixins.ROOT_PASSWORD, password);
             entity.config().set(MongoDBAuthenticationMixins.ROOT_PASSWORD, password);
         }

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7SshDriver.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7SshDriver.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.apache.brooklyn.core.entity.Entities;
 import org.apache.brooklyn.entity.software.base.SoftwareProcess;
 import org.apache.brooklyn.entity.webapp.JavaWebAppSshDriver;
+import org.apache.brooklyn.util.text.Identifiers;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
@@ -145,7 +146,7 @@ public class JBoss7SshDriver extends JavaWebAppSshDriver implements JBoss7Driver
         String managementPassword = getManagementPassword();
         if (Strings.isBlank(managementPassword)) {
             LOG.debug(this+" has no password specified for "+JBoss7Server.MANAGEMENT_PASSWORD.getName()+"; using a random string");
-            entity.config().set(JBoss7Server.MANAGEMENT_PASSWORD, Strings.makeRandomId(8));
+            entity.config().set(JBoss7Server.MANAGEMENT_PASSWORD, Identifiers.makeRandomPassword(8));
         }
         String hashedPassword = hashPassword(getManagementUsername(), getManagementPassword(), MANAGEMENT_REALM);
 


### PR DESCRIPTION
`Strings.makeRandomId` uses a insecure random so we shouldn't be using it for passwords, I've swapped it to `Identifiers.makeRandomPassword` which does use secure random.