### PR TITLE
Specify Java version for JBoss

### DIFF
--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss6SshDriver.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss6SshDriver.java
@@ -90,6 +90,14 @@ public class JBoss6SshDriver extends JavaWebAppSshDriver implements JBoss6Driver
     }
 
     @Override
+    public boolean installJava() {
+        /*
+         * JBoss only works on Java 7 or lower, see here: https://developer.jboss.org/message/808212
+         */
+        return checkForAndInstallJava("1.7");
+    }
+
+    @Override
     public void install() {
         List<String> urls = resolver.getTargets();
         String saveAs = resolver.getFilename();

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7SshDriver.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7SshDriver.java
@@ -110,6 +110,14 @@ public class JBoss7SshDriver extends JavaWebAppSshDriver implements JBoss7Driver
     }
 
     @Override
+    public boolean installJava() {
+        /*
+         * JBoss only works on Java 7 or lower, see here: https://developer.jboss.org/message/808212
+         */
+        return checkForAndInstallJava("1.7");
+    }
+
+    @Override
     public void install() {
         List<String> urls = resolver.getTargets();
         String saveAs = resolver.getFilename();


### PR DESCRIPTION
JBoss does not work on Java 1.8 or above (see here: https://developer.jboss.org/message/808212) so specify this here as opposed to falling back to the default.

Tested on CentOS / Ubuntu