### PR TITLE
Fix jetty6.install

### DIFF
--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jetty/Jetty6SshDriver.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jetty/Jetty6SshDriver.java
@@ -57,7 +57,7 @@ public class Jetty6SshDriver extends JavaWebAppSshDriver implements Jetty6Driver
 
         List<String> commands = new LinkedList<String>();
         commands.addAll(BashCommands.commandsToDownloadUrlsAs(urls, saveAs));
-        commands.add(BashCommands.INSTALL_ZIP);
+        commands.add(BashCommands.INSTALL_UNZIP);
         commands.add("unzip "+saveAs);
 
         newScript(INSTALLING)


### PR DESCRIPTION
(Previously only worked on linux if unzip was already installed, or
if `yum install -y zip` would also install unzip).