### PR TITLE
Fix GeoDNS tests

### DIFF
--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/dns/AbstractGeoDnsServiceTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/dns/AbstractGeoDnsServiceTest.java
@@ -166,8 +166,8 @@ public class AbstractGeoDnsServiceTest extends BrooklynAppUnitTestSupport {
                 .configure("latitude", lat)
                 .configure("longitude", lon);
     }
-    
-    @Test
+
+    @Test(groups="Integration")
     public void testGeoInfoOnLocation() {
         app.start( ImmutableList.of(westChildWithLocation, eastChildWithLocationAndWithPrivateHostname) );
         publishSensors(2, true, true, true);
@@ -177,7 +177,7 @@ public class AbstractGeoDnsServiceTest extends BrooklynAppUnitTestSupport {
         assertIsTarget("East child with location");
     }
 
-    @Test
+    @Test(groups="Integration")
     public void testGeoInfoOnParentLocation() {
         app.start( ImmutableList.of(westChild, eastChild) );
         publishSensors(2, true, false, false);
@@ -187,7 +187,7 @@ public class AbstractGeoDnsServiceTest extends BrooklynAppUnitTestSupport {
         assertIsTarget("East child");
     }
 
-    @Test
+    @Test(groups="Integration")
     public void testSubscribesToHostname() {
         geoDns.config().set(GeoDnsTestServiceImpl.ADD_ANYTHING, false);
         app.start( ImmutableList.of(westChild, eastChildWithLocationAndWithPrivateHostname) );
@@ -219,7 +219,7 @@ public class AbstractGeoDnsServiceTest extends BrooklynAppUnitTestSupport {
         }
     }
 
-    @Test
+    @Test(groups="Integration")
     public void testChildAddedLate() {
         app.start( ImmutableList.of(westChild, eastChildWithLocationAndWithPrivateHostname) );
         publishSensors(2, true, false, false);
@@ -238,7 +238,7 @@ public class AbstractGeoDnsServiceTest extends BrooklynAppUnitTestSupport {
         log.info("targets: "+geoDns.getTargetHostsByName());
     }
 
-    @Test
+    @Test(groups="Integration")
     public void testFiltersEntirelyPrivate() {
         geoDns.config().set(GeoDnsTestServiceImpl.ADD_ANYTHING, false);
         app.start( ImmutableList.of(westChild, eastChildWithLocationAndWithPrivateHostname, northChildWithLocation) );
@@ -276,7 +276,7 @@ public class AbstractGeoDnsServiceTest extends BrooklynAppUnitTestSupport {
         assertAttributeEventually(geoDns, AbstractGeoDnsService.TARGETS, CollectionFunctionals.<String>mapSizeEquals(2));
     }
 
-    @Test
+    @Test(groups="Integration")
     public void testCanDisableFilterForRunningEntities() throws Exception {
         geoDns.config().set(AbstractGeoDnsService.FILTER_FOR_RUNNING, false);
         app.start(ImmutableList.of(westChildWithLocation, eastChildWithLocationAndWithPrivateHostname));


### PR DESCRIPTION
The GEODNS tests are currently failing:
```
 2017-05-10 03:59:21,695 ERROR Problem refreshing group membership: org.apache.brooklyn.util.exceptions.RuntimeInterruptedException: java.lang.InterruptedException
org.apache.brooklyn.util.exceptions.RuntimeInterruptedException: java.lang.InterruptedException
	at org.apache.brooklyn.util.exceptions.Exceptions.propagate(Exceptions.java:124) ~[brooklyn-utils-common-0.12.0-SNAPSHOT.jar:0.12.0-SNAPSHOT]
Caused by: java.lang.InterruptedException: null
	at java.util.concurrent.FutureTask.awaitDone(FutureTask.java:404) [na:1.8.0_121]
Tests run: 42, Failures: 1, Errors: 0, Skipped: 22, Time elapsed: 57.834 sec <<< FAILURE! - in TestSuite
tearDown(org.apache.brooklyn.entity.dns.AbstractGeoDnsServiceTest)  Time elapsed: 31.464 sec  <<< FAILURE!
org.testng.internal.thread.ThreadTimeoutException: Method org.apache.brooklyn.core.test.BrooklynMgmtUnitTestSupport.tearDown() didn't finish within the time-out 30000


Results :

Failed tests: 
  AbstractGeoDnsServiceTest>BrooklynMgmtUnitTestSupport.tearDown:58->BrooklynMgmtUnitTestSupport.destroyManagementContextSafely:71 » ThreadTimeout
```
This swaps them to integration tests.