### PR TITLE
[WIP] Put back GeoDNS tests

### DIFF
--- a/software/webapp/src/test/java/org/apache/brooklyn/entity/dns/AbstractGeoDnsServiceTest.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/entity/dns/AbstractGeoDnsServiceTest.java
@@ -167,7 +167,7 @@ public class AbstractGeoDnsServiceTest extends BrooklynAppUnitTestSupport {
                 .configure("longitude", lon);
     }
 
-    @Test(groups="Integration")
+    @Test
     public void testGeoInfoOnLocation() {
         app.start( ImmutableList.of(westChildWithLocation, eastChildWithLocationAndWithPrivateHostname) );
         publishSensors(2, true, true, true);
@@ -177,7 +177,7 @@ public class AbstractGeoDnsServiceTest extends BrooklynAppUnitTestSupport {
         assertIsTarget("East child with location");
     }
 
-    @Test(groups="Integration")
+    @Test
     public void testGeoInfoOnParentLocation() {
         app.start( ImmutableList.of(westChild, eastChild) );
         publishSensors(2, true, false, false);
@@ -187,7 +187,7 @@ public class AbstractGeoDnsServiceTest extends BrooklynAppUnitTestSupport {
         assertIsTarget("East child");
     }
 
-    @Test(groups="Integration")
+    @Test
     public void testSubscribesToHostname() {
         geoDns.config().set(GeoDnsTestServiceImpl.ADD_ANYTHING, false);
         app.start( ImmutableList.of(westChild, eastChildWithLocationAndWithPrivateHostname) );
@@ -219,7 +219,7 @@ public class AbstractGeoDnsServiceTest extends BrooklynAppUnitTestSupport {
         }
     }
 
-    @Test(groups="Integration")
+    @Test
     public void testChildAddedLate() {
         app.start( ImmutableList.of(westChild, eastChildWithLocationAndWithPrivateHostname) );
         publishSensors(2, true, false, false);
@@ -238,7 +238,7 @@ public class AbstractGeoDnsServiceTest extends BrooklynAppUnitTestSupport {
         log.info("targets: "+geoDns.getTargetHostsByName());
     }
 
-    @Test(groups="Integration")
+    @Test
     public void testFiltersEntirelyPrivate() {
         geoDns.config().set(GeoDnsTestServiceImpl.ADD_ANYTHING, false);
         app.start( ImmutableList.of(westChild, eastChildWithLocationAndWithPrivateHostname, northChildWithLocation) );
@@ -276,7 +276,7 @@ public class AbstractGeoDnsServiceTest extends BrooklynAppUnitTestSupport {
         assertAttributeEventually(geoDns, AbstractGeoDnsService.TARGETS, CollectionFunctionals.<String>mapSizeEquals(2));
     }
 
-    @Test(groups="Integration")
+    @Test
     public void testCanDisableFilterForRunningEntities() throws Exception {
         geoDns.config().set(AbstractGeoDnsService.FILTER_FOR_RUNNING, false);
         app.start(ImmutableList.of(westChildWithLocation, eastChildWithLocationAndWithPrivateHostname));


### PR DESCRIPTION
As @neykov noticed in #106, the failure of these tests could be down to a deadlock fixed in apache/brooklyn-server#671. This puts the tests back. 