### PR TITLE
Delete use of entity constructors

### DIFF
--- a/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlNodeImpl.java
+++ b/software/database/src/main/java/org/apache/brooklyn/entity/database/mysql/MySqlNodeImpl.java
@@ -18,9 +18,6 @@
  */
 package org.apache.brooklyn.entity.database.mysql;
 
-import java.util.Map;
-
-import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.core.effector.EffectorBody;
 import org.apache.brooklyn.core.location.Locations;
 import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
@@ -28,7 +25,6 @@ import org.apache.brooklyn.feed.ssh.SshFeed;
 import org.apache.brooklyn.feed.ssh.SshPollConfig;
 import org.apache.brooklyn.feed.ssh.SshPollValue;
 import org.apache.brooklyn.location.ssh.SshMachineLocation;
-import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.config.ConfigBag;
 import org.apache.brooklyn.util.guava.Maybe;
 import org.apache.brooklyn.util.text.Identifiers;
@@ -49,21 +45,6 @@ public class MySqlNodeImpl extends SoftwareProcessImpl implements MySqlNode {
     String DEFAULT_USERNAME = "root";
 
     private SshFeed feed;
-
-    public MySqlNodeImpl() {
-    }
-
-    public MySqlNodeImpl(Entity parent) {
-        this(MutableMap.of(), parent);
-    }
-
-    public MySqlNodeImpl(Map<?,?> flags) {
-        super(flags, null);
-    }
-
-    public MySqlNodeImpl(Map<?,?> flags, Entity parent) {
-        super(flags, parent);
-    }
 
     @Override
     public Class<?> getDriverInterface() {

--- a/software/monitoring/src/main/java/org/apache/brooklyn/entity/monitoring/monit/MonitNodeImpl.java
+++ b/software/monitoring/src/main/java/org/apache/brooklyn/entity/monitoring/monit/MonitNodeImpl.java
@@ -18,9 +18,6 @@
  */
 package org.apache.brooklyn.entity.monitoring.monit;
 
-import java.util.Map;
-
-import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.api.location.Location;
 import org.apache.brooklyn.entity.software.base.SoftwareProcessImpl;
 import org.apache.brooklyn.feed.ssh.SshFeed;
@@ -40,17 +37,6 @@ public class MonitNodeImpl extends SoftwareProcessImpl implements MonitNode {
     
     private SshFeed feed;
     
-    public MonitNodeImpl() {
-    }
-    
-    public MonitNodeImpl(Map<?,?> flags) {
-        super(flags, null);
-    }
-    
-    public MonitNodeImpl(Map<?,?> flags, Entity parent) {
-        super(flags, parent);
-    }
-
     @Override
     public Class<? extends MonitDriver> getDriverInterface() {
         return MonitDriver.class;

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/proxy/AbstractControllerImpl.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/proxy/AbstractControllerImpl.java
@@ -83,25 +83,6 @@ public abstract class AbstractControllerImpl extends SoftwareProcessImpl impleme
     // final because this is the synch target
     final protected Set<String> serverPoolAddresses = Sets.newLinkedHashSet();
     
-    public AbstractControllerImpl() {
-        this(MutableMap.of(), null, null);
-    }
-    public AbstractControllerImpl(Map<?, ?> properties) {
-        this(properties, null, null);
-    }
-    public AbstractControllerImpl(Entity parent) {
-        this(MutableMap.of(), parent, null);
-    }
-    public AbstractControllerImpl(Map<?, ?> properties, Entity parent) {
-        this(properties, parent, null);
-    }
-    public AbstractControllerImpl(Entity parent, Cluster cluster) {
-        this(MutableMap.of(), parent, cluster);
-    }
-    public AbstractControllerImpl(Map<?, ?> properties, Entity parent, Cluster cluster) {
-        super(properties, parent);
-    }
-
     @Override
     public void init() {
         super.init();

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/ControlledDynamicWebAppClusterImpl.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/ControlledDynamicWebAppClusterImpl.java
@@ -57,23 +57,6 @@ public class ControlledDynamicWebAppClusterImpl extends DynamicGroupImpl impleme
 
     public static final Logger log = LoggerFactory.getLogger(ControlledDynamicWebAppClusterImpl.class);
 
-    public ControlledDynamicWebAppClusterImpl() {
-        this(MutableMap.of(), null);
-    }
-    
-    public ControlledDynamicWebAppClusterImpl(Map<?,?> flags) {
-        this(flags, null);
-    }
-    
-    public ControlledDynamicWebAppClusterImpl(Entity parent) {
-        this(MutableMap.of(), parent);
-    }
-    
-    @Deprecated
-    public ControlledDynamicWebAppClusterImpl(Map<?,?> flags, Entity parent) {
-        super(flags, parent);
-    }
-
     @Override
     public void init() {
         super.init();

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/JavaWebAppSoftwareProcessImpl.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/JavaWebAppSoftwareProcessImpl.java
@@ -21,12 +21,10 @@ package org.apache.brooklyn.entity.webapp;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.core.annotation.Effector;
 import org.apache.brooklyn.core.annotation.EffectorParam;
 import org.apache.brooklyn.entity.java.JavaAppUtils;
@@ -40,25 +38,6 @@ import com.google.common.collect.Sets;
 public abstract class JavaWebAppSoftwareProcessImpl extends SoftwareProcessImpl implements JavaWebAppService, JavaWebAppSoftwareProcess {
 
     private static final Logger LOG = LoggerFactory.getLogger(JavaWebAppSoftwareProcessImpl.class);
-
-    public JavaWebAppSoftwareProcessImpl(){
-        super();
-    }
-
-    @SuppressWarnings("rawtypes")
-    public JavaWebAppSoftwareProcessImpl(Entity parent){
-        this(new LinkedHashMap(),parent);
-    }
-
-    @SuppressWarnings("rawtypes")
-    public JavaWebAppSoftwareProcessImpl(Map flags){
-        this(flags, null);
-    }
-
-    @SuppressWarnings("rawtypes")
-    public JavaWebAppSoftwareProcessImpl(Map flags, Entity parent) {
-        super(flags, parent);
-    }
 
     @Override
     public void init() {

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss6ServerImpl.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss6ServerImpl.java
@@ -18,11 +18,8 @@
  */
 package org.apache.brooklyn.entity.webapp.jboss;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.core.entity.EntityFunctions;
 import org.apache.brooklyn.entity.java.UsesJmx;
 import org.apache.brooklyn.entity.webapp.JavaWebAppSoftwareProcessImpl;
@@ -39,22 +36,6 @@ public class JBoss6ServerImpl extends JavaWebAppSoftwareProcessImpl implements J
 
     private volatile JmxFeed jmxFeed;
     
-    public JBoss6ServerImpl() {
-        this(new LinkedHashMap(), null);
-    }
-
-    public JBoss6ServerImpl(Entity parent) {
-        this(new LinkedHashMap(), parent);
-    }
-
-    public JBoss6ServerImpl(Map flags){
-        this(flags, null);
-    }
-
-    public JBoss6ServerImpl(Map flags, Entity parent) {
-        super(flags, parent);
-    }
-
     @Override
     public void connectSensors() {
         super.connectSensors();

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7ServerImpl.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7ServerImpl.java
@@ -20,7 +20,6 @@ package org.apache.brooklyn.entity.webapp.jboss;
 
 import java.util.Map;
 
-import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.core.config.render.RendererHints;
 import org.apache.brooklyn.core.entity.Attributes;
 import org.apache.brooklyn.core.entity.EntityFunctions;
@@ -44,18 +43,6 @@ public class JBoss7ServerImpl extends JavaWebAppSoftwareProcessImpl implements J
 
     private volatile HttpFeed httpFeed;
     
-    public JBoss7ServerImpl(){
-        super();
-    }
-
-    public JBoss7ServerImpl(@SuppressWarnings("rawtypes") Map flags){
-        this(flags, null);
-    }
-
-    public JBoss7ServerImpl(@SuppressWarnings("rawtypes") Map flags, Entity parent) {
-        super(flags, parent);
-    }
-
     @Override
     public Class<?> getDriverInterface() {
         return JBoss7Driver.class;

--- a/software/webapp/src/test/java/org/apache/brooklyn/test/entity/TestJavaWebAppEntityImpl.java
+++ b/software/webapp/src/test/java/org/apache/brooklyn/test/entity/TestJavaWebAppEntityImpl.java
@@ -18,9 +18,6 @@
  */
 package org.apache.brooklyn.test.entity;
 
-import java.util.Map;
-
-import org.apache.brooklyn.api.entity.Entity;
 import org.apache.brooklyn.entity.java.VanillaJavaAppImpl;
 import org.apache.brooklyn.entity.webapp.WebAppServiceConstants;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
@@ -30,11 +27,6 @@ public class TestJavaWebAppEntityImpl extends VanillaJavaAppImpl implements Test
     @SetFromFlag public int a;
     @SetFromFlag public int b;
     @SetFromFlag public int c;
-
-    public TestJavaWebAppEntityImpl() {}
-    
-    // constructor required for use in DynamicCluster.factory
-    public TestJavaWebAppEntityImpl(@SuppressWarnings("rawtypes") Map flags, Entity parent) { super(flags, parent); }
 
     @Override
     public synchronized void spoofRequest() {


### PR DESCRIPTION
Accompanies https://github.com/apache/brooklyn-server/pull/679, deleting entity constructors (because we should always use `EntitySpec` to create entities).