### PR TITLE
Fix Nginx dependencies

### DIFF
--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/proxy/nginx/NginxSshDriver.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/proxy/nginx/NginxSshDriver.java
@@ -165,6 +165,7 @@ public class NginxSshDriver extends AbstractSoftwareProcessSshDriver implements 
 
         List<String> cmds = Lists.newArrayList();
 
+        cmds.add(BashCommands.ifExecutableElse0("yum", BashCommands.sudo("yum -y install kernel-headers --disableexcludes=all")));
         cmds.add(BashCommands.INSTALL_TAR);
         cmds.add(BashCommands.alternatives(
                 BashCommands.ifExecutableElse0("apt-get", BashCommands.installPackage("build-essential")),


### PR DESCRIPTION
On some clouds, notably Azure with CentOS, `kernel-headers` is in the disbaled list which causes `gcc` to not install properly. This uses the `--disableexcludes=all` to install it.

Tested with Azure/CentOS7, AWS/Ubuntu16 