### PR TITLE
Bring namespace on feature files to Karaf features 1.4.0

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -16,10 +16,10 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 -->
-<features xmlns="http://karaf.apache.org/xmlns/features/v1.2.0"
+<features xmlns="http://karaf.apache.org/xmlns/features/v1.4.0"
           name="org.apache.brooklyn-${project.version}"
           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-          xsi:noNamespaceSchemaLocation="http://karaf.apache.org/xmlns/features/v1.2.0">
+          xsi:noNamespaceSchemaLocation="http://karaf.apache.org/xmlns/features/v1.4.0">
 
     <feature name="brooklyn-software-network" version="${project.version}" description="Brooklyn Network Software Entities">
         <bundle>mvn:org.apache.brooklyn/brooklyn-software-network/${project.version}</bundle>


### PR DESCRIPTION
Updates namespace on the file to http://karaf.apache.org/xmlns/features/v1.4.0
which is required for 'prerequisite="true"' on feature declarations.