### PR TITLE
Update MariaDB version

### DIFF
--- a/software/database/src/main/java/org/apache/brooklyn/entity/database/mariadb/MariaDbNode.java
+++ b/software/database/src/main/java/org/apache/brooklyn/entity/database/mariadb/MariaDbNode.java
@@ -42,7 +42,7 @@ public interface MariaDbNode extends SoftwareProcess, DatastoreCommon, HasShortN
 
     @SetFromFlag("version")
     public static final ConfigKey<String> SUGGESTED_VERSION =
-        ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "5.5.53");
+        ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "10.2.6");
 
     // https://downloads.mariadb.org/interstitial/mariadb-5.5.33a/kvm-bintar-hardy-amd64/mariadb-5.5.33a-linux-x86_64.tar.gz/from/http://mirrors.coreix.net/mariadb
     // above redirects to download the artifactd from the URLs below.


### PR DESCRIPTION
MariaDB version `5.5.53` is no longer available so update to the latest version `10.2.6`.