### PR TITLE
Fix use of deprecated Objects.toStringHelper

### DIFF
--- a/qa/src/main/java/org/apache/brooklyn/qa/longevity/MonitorPrefs.java
+++ b/qa/src/main/java/org/apache/brooklyn/qa/longevity/MonitorPrefs.java
@@ -21,7 +21,7 @@ package org.apache.brooklyn.qa.longevity;
 import java.io.File;
 import java.net.URL;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.Range;
 
 public class MonitorPrefs {
@@ -39,7 +39,7 @@ public class MonitorPrefs {
     
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("webUrl", webUrl)
                 .add("brooklynPid", brooklynPid)
                 .add("logFile", logFile)

--- a/qa/src/main/java/org/apache/brooklyn/qa/longevity/MonitorUtils.java
+++ b/qa/src/main/java/org/apache/brooklyn/qa/longevity/MonitorUtils.java
@@ -41,7 +41,7 @@ import org.apache.brooklyn.util.stream.StreamGobbler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -209,7 +209,7 @@ public class MonitorUtils {
 
         @Override
         public String toString() {
-            return Objects.toStringHelper(this)
+            return MoreObjects.toStringHelper(this)
                     .add("totalInstances", totalInstances)
                     .add("totalMemoryBytes", totalMemoryBytes)
                     .add("instanceCounts", instanceCounts)

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/mongodb/MongoDBServerImpl.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/mongodb/MongoDBServerImpl.java
@@ -34,7 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Functions;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.net.HostAndPort;
 
 public class MongoDBServerImpl extends SoftwareProcessImpl implements MongoDBServer {
@@ -218,7 +218,7 @@ public class MongoDBServerImpl extends SoftwareProcessImpl implements MongoDBSer
 
     @Override
     public String toString() {
-        return Objects.toStringHelper(this)
+        return MoreObjects.toStringHelper(this)
                 .add("id", getId())
                 .add("hostname", sensors().get(HOSTNAME))
                 .add("port", sensors().get(PORT))


### PR DESCRIPTION
Use `MoreObjects.toStringHelper`, instead of the deprecated `Objects.toStringHelper`.