### PR TITLE
Fix MariaDBNode default mirrorUrl

### DIFF
--- a/software/database/src/main/java/org/apache/brooklyn/entity/database/mariadb/MariaDbNode.java
+++ b/software/database/src/main/java/org/apache/brooklyn/entity/database/mariadb/MariaDbNode.java
@@ -57,7 +57,7 @@ public interface MariaDbNode extends SoftwareProcess, DatastoreCommon, HasShortN
     /** download mirror, if desired */
     @SetFromFlag("mirrorUrl")
     public static final ConfigKey<String> MIRROR_URL = ConfigKeys.newStringConfigKey("mariadb.install.mirror.url", "URL of mirror",
-        "http://mirrors.coreix.net/mariadb"
+        "http://ftp.hosteurope.de/mirror/archive.mariadb.org"
      );
 
     @SetFromFlag("port")


### PR DESCRIPTION
 - the existing default mirror does not keep all the old versions