### PR TITLE
Update package for chef bean due to the move to brooklyn-library

### DIFF
--- a/software/cm/chef/src/main/resources/OSGI-INF/blueprint/blueprint.xml
+++ b/software/cm/chef/src/main/resources/OSGI-INF/blueprint/blueprint.xml
@@ -24,7 +24,7 @@ limitations under the License.
              ">
 
     <bean id="chefEntitySpecResolver" scope="prototype"
-             class="org.apache.brooklyn.entity.resolve.ChefEntitySpecResolver"/>
+             class="org.apache.brooklyn.entity.chef.resolve.ChefEntitySpecResolver"/>
     <service id="chefEntitySpecResolverService" ref="chefEntitySpecResolver"
              interface="org.apache.brooklyn.core.resolve.entity.EntitySpecResolver" />
 


### PR DESCRIPTION
This fixes a little mistake I let in when I reviewed #129