### PR TITLE
Update config keys' deprecated names

### DIFF
--- a/examples/simple-web-cluster/src/main/resources/org/apache/brooklyn/demo/nodejs-riak-todo.yaml
+++ b/examples/simple-web-cluster/src/main/resources/org/apache/brooklyn/demo/nodejs-riak-todo.yaml
@@ -43,4 +43,4 @@ services:
       NODE_ENV: production
       RIAK_NODES: >
         $brooklyn:component("mycluster").attributeWhenReady("riak.cluster.nodeListPbPort")
-    launch.latch: $brooklyn:component("mycluster").attributeWhenReady("service.isUp")
+    latch.launch: $brooklyn:component("mycluster").attributeWhenReady("service.isUp")

--- a/examples/simple-web-cluster/src/main/resources/org/apache/brooklyn/demo/nodejs-todo.yaml
+++ b/examples/simple-web-cluster/src/main/resources/org/apache/brooklyn/demo/nodejs-todo.yaml
@@ -50,4 +50,4 @@ services:
         $brooklyn:formatString("redis://%s:%d/",
           component("redis").attributeWhenReady("host.subnet.hostname"),
           component("redis").attributeWhenReady("redis.port"))
-    launch.latch: $brooklyn:component("redis").attributeWhenReady("service.isUp")
+    latch.launch: $brooklyn:component("redis").attributeWhenReady("service.isUp")


### PR DESCRIPTION
Since Brooklyn 0.12.0 ([this PR](https://github.com/apache/brooklyn-server/pull/819) precisely) some config keys' name have been deprecated generated a warning when installing a blueprint using those. 

This fixes it by using the new names.