### PR TITLE
Fix Library Feature File

### DIFF
--- a/karaf/features/src/main/feature/feature.xml
+++ b/karaf/features/src/main/feature/feature.xml
@@ -75,6 +75,10 @@
         <bundle dependency="true">mvn:com.google.guava/guava/${guava.version}</bundle>
     </feature>
 
+    <feature name="brooklyn-library-catalog" version="${project.version}" description="Brooklyn Library Catalog">
+        <bundle>mvn:org.apache.brooklyn/brooklyn-library-catalog/${project.version}</bundle>
+    </feature>
+
     <feature name="brooklyn-library-all" version="${project.version}" description="Brooklyn All Library Entities">
         <feature>brooklyn-software-network</feature>
         <feature>brooklyn-software-cm</feature>
@@ -84,6 +88,7 @@
         <feature>brooklyn-software-messaging</feature>
         <feature>brooklyn-software-nosql</feature>
         <feature>brooklyn-software-monitoring</feature>
+        <feature>brooklyn-library-catalog</feature>
     </feature>
 
 


### PR DESCRIPTION
**Issue**
When building Brooklyn karaf, brooklyn-library-catalog is not included in the system folder. This means that on startup Karaf goes to a remote repository (sonatype) or local maven cache to retrieve it. A separate PR will be created to stop Brooklyn from using remote repos.

**Fix**
Update the feature brooklyn-library-all such that it contains a reference to the brooklyn-library-catalog bundle. This means that when building Brooklyn, brooklyn-library-catalog is included in the systems folder.