### PR TITLE
Fix NPE in CouchbaseCluster enricher

### DIFF
--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/couchbase/CouchbaseClusterImpl.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/couchbase/CouchbaseClusterImpl.java
@@ -290,6 +290,7 @@ public class CouchbaseClusterImpl extends DynamicClusterImpl implements Couchbas
     private final static class ListOfHostAndPort implements Function<Set<Entity>, List<String>> {
         @Override public List<String> apply(Set<Entity> input) {
             List<String> addresses = Lists.newArrayList();
+            if (input == null) return addresses;
             for (Entity entity : input) {
                 addresses.add(String.format("%s",
                         BrooklynAccessUtils.getBrooklynAccessibleAddress(entity, entity.getAttribute(CouchbaseNode.COUCHBASE_WEB_ADMIN_PORT))));


### PR DESCRIPTION
I saw this exception, which would happen when the enricher is triggered with the sensor `couchbase.cluster.clusterEntities` that has a null value.

```
2017-12-20T23:25:58,096 WARN  123 o.a.b.c.m.i.LocalSubscriptionManager [ager-uluKzucE-12] Error processing subscriptions to LSM.publishInitial(CouchbaseClusterImpl{id=fzixius98s}.Sensor: couchbase.cluster.clusterEntities (java.util.Set)=null @ 1513812358095): java.lang.NullPointerException
java.lang.NullPointerException: null
        at org.apache.brooklyn.entity.nosql.couchbase.CouchbaseClusterImpl$ListOfHostAndPort.apply(CouchbaseClusterImpl.java:293) ~[?:?]
        at org.apache.brooklyn.entity.nosql.couchbase.CouchbaseClusterImpl$ListOfHostAndPort.apply(CouchbaseClusterImpl.java:290) ~[?:?]
        at org.apache.brooklyn.enricher.stock.Transformer$4.apply(Transformer.java:98) ~[?:?]
        at org.apache.brooklyn.enricher.stock.Transformer$4.apply(Transformer.java:95) ~[?:?]
        at org.apache.brooklyn.enricher.stock.AbstractTransformer.compute(AbstractTransformer.java:163) ~[?:?]
        at org.apache.brooklyn.enricher.stock.AbstractTransformer.onEvent(AbstractTransformer.java:157) ~[?:?]
        at org.apache.brooklyn.core.mgmt.internal.LocalSubscriptionManager$1.run(LocalSubscriptionManager.java:351) ~[?:?]
        at org.apache.brooklyn.core.mgmt.internal.LocalSubscriptionManager.submitPublishEvent(LocalSubscriptionManager.java:370) ~[?:?]
        at org.apache.brooklyn.core.mgmt.internal.LocalSubscriptionManager.lambda$subscribe$0(LocalSubscriptionManager.java:204) ~[?:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511) [?:?]
        at org.apache.brooklyn.util.core.task.BasicExecutionManager$SubmissionCallable.call(BasicExecutionManager.java:565) [123:org.apache.brooklyn.core:1.0.0.20171219_1516]
        at org.apache.brooklyn.util.core.task.SingleThreadedScheduler$1.call(SingleThreadedScheduler.java:116) [123:org.apache.brooklyn.core:1.0.0.20171219_1516]
        at java.util.concurrent.FutureTask.run(FutureTask.java:266) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624) [?:?]
        at java.lang.Thread.run(Thread.java:748) [?:?]
```