### PR TITLE
Adds AbstractController changeServerPool

### DIFF
--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/proxy/LoadBalancer.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/proxy/LoadBalancer.java
@@ -27,6 +27,7 @@ import org.apache.brooklyn.api.entity.Group;
 import org.apache.brooklyn.api.sensor.AttributeSensor;
 import org.apache.brooklyn.config.ConfigKey;
 import org.apache.brooklyn.core.annotation.Effector;
+import org.apache.brooklyn.core.annotation.EffectorParam;
 import org.apache.brooklyn.core.config.BasicConfigKey;
 import org.apache.brooklyn.core.effector.MethodEffector;
 import org.apache.brooklyn.core.entity.Attributes;
@@ -131,6 +132,10 @@ public interface LoadBalancer extends Entity, Startable {
     public static final MethodEffector<Void> RELOAD = new MethodEffector<Void>(LoadBalancer.class, "reload");
     
     public static final MethodEffector<Void> UPDATE = new MethodEffector<Void>(LoadBalancer.class, "update");
+
+    @Effector(description="Change the target server pool")
+    public void changeServerPool(
+            @EffectorParam(name="groupId") String groupId);
 
     @Effector(description="Forces reload of the configuration")
     public void reload();

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/proxy/LoadBalancerClusterImpl.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/proxy/LoadBalancerClusterImpl.java
@@ -21,6 +21,7 @@ package org.apache.brooklyn.entity.proxy;
 import java.util.Map;
 
 import org.apache.brooklyn.api.entity.Entity;
+import org.apache.brooklyn.api.entity.Group;
 import org.apache.brooklyn.entity.group.DynamicClusterImpl;
 
 /**
@@ -70,6 +71,20 @@ public class LoadBalancerClusterImpl extends DynamicClusterImpl implements LoadB
         for (Entity member : getMembers()) {
             if (member instanceof LoadBalancer) {
                 ((LoadBalancer)member).bind(flags);
+            }
+        }
+    }
+    
+    @Override
+    public void changeServerPool(String groupId) {
+        Group newGroup = (Group) getManagementContext().getEntityManager().getEntity(groupId);
+        if (newGroup == null) {
+            throw new IllegalArgumentException("Group '"+groupId+"' not found");
+        }
+        
+        for (Entity member : getMembers()) {
+            if (member instanceof LoadBalancer) {
+                ((LoadBalancer)member).changeServerPool(groupId);
             }
         }
     }


### PR DESCRIPTION
Builds on https://github.com/apache/brooklyn-library/pull/146, which contains the first two comits - please review/merge that first.

Purpose of the new `changeServerPool` effector is to switch the group of target servers, and thus reconfigure the load balancer in one step.

This would be useful for example in blue-green upgrades: the load balancer could start by pointing at the "blue" cluster, and could then be switched to point at the "green" cluster.