### PR TITLE
Deprecate JBoss 7 entity

### DIFF
--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7Driver.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7Driver.java
@@ -20,6 +20,10 @@ package org.apache.brooklyn.entity.webapp.jboss;
 
 import org.apache.brooklyn.entity.webapp.JavaWebAppDriver;
 
+/**
+ * @deprecated since 1.0.0; JBoss 7 is EOF
+ */
+@Deprecated
 public interface JBoss7Driver extends JavaWebAppDriver{
 
     /**

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7Server.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7Server.java
@@ -33,6 +33,10 @@ import org.apache.brooklyn.util.core.ResourcePredicates;
 import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.javalang.JavaClassNames;
 
+/**
+ * @deprecated since 1.0.0; JBoss 7 is EOF
+ */
+@Deprecated
 @Catalog(name="JBoss Application Server 7", description="AS7: an open source Java application server from JBoss", iconUrl="classpath:///jboss-logo.png")
 @ImplementedBy(JBoss7ServerImpl.class)
 public interface JBoss7Server extends JavaWebAppSoftwareProcess, HasShortName {

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7ServerImpl.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7ServerImpl.java
@@ -37,6 +37,10 @@ import com.google.common.base.Functions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HostAndPort;
 
+/**
+ * @deprecated since 1.0.0; JBoss 7 is EOF
+ */
+@Deprecated
 public class JBoss7ServerImpl extends JavaWebAppSoftwareProcessImpl implements JBoss7Server {
 
     public static final Logger log = LoggerFactory.getLogger(JBoss7ServerImpl.class);

--- a/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7SshDriver.java
+++ b/software/webapp/src/main/java/org/apache/brooklyn/entity/webapp/jboss/JBoss7SshDriver.java
@@ -45,6 +45,10 @@ import com.google.common.base.Preconditions;
 import com.google.common.hash.Hashing;
 import com.google.common.io.BaseEncoding;
 
+/**
+ * @deprecated since 1.0.0; JBoss 7 is EOF
+ */
+@Deprecated
 public class JBoss7SshDriver extends JavaWebAppSshDriver implements JBoss7Driver {
 
     private static final Logger LOG = LoggerFactory.getLogger(JBoss7SshDriver.class);

--- a/software/webapp/src/main/resources/catalog.bom
+++ b/software/webapp/src/main/resources/catalog.bom
@@ -28,8 +28,9 @@ brooklyn.catalog:
       iconUrl: classpath:///jboss_logo.png
       item:
         type: org.apache.brooklyn.entity.webapp.jboss.JBoss7Server
-        name: JBoss Application Server 7
+        name: "[DEPRECATED] JBoss Application Server 7"
         description: AS7 - an open source Java application server from JBoss
+        deprecated: true
     - id: org.apache.brooklyn.entity.proxy.nginx.UrlMapping
       item:
         type: org.apache.brooklyn.entity.proxy.nginx.UrlMapping


### PR DESCRIPTION
As the title, this deprecates JBoss 7, mainly because it is EOF.

See discussion here: https://lists.apache.org/thread.html/26d0225c8608fb398c2ea7b2d097a8a8784710c3bc7ea86270da28b4@%3Cdev.brooklyn.apache.org%3E