### PR TITLE
Use the settings.xml from Jenkins to deploy artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,8 +44,8 @@ node(label: 'ubuntu') {
             // Conditional stage to deploy artifacts, when not building a PR
             if (env.CHANGE_ID == null) {
                 stage('Deploy artifacts') {
-                    environmentDockerImage.inside('-i --name brooklyn-${DOCKER_TAG} -v ${WORKSPACE}/.m2:/root/.m2 -v ${WORKSPACE}:/usr/build -w /usr/build') {
-                        sh 'mvn deploy -DskipTests'
+                    environmentDockerImage.inside('-i --name brooklyn-${DOCKER_TAG} -v ${HOME}:/usr/home -v ${WORKSPACE}/.m2:/root/.m2 -v ${WORKSPACE}:/usr/build -w /usr/build') {
+                        sh 'mvn deploy -s /usr/home/.m2/settings.xml -DskipTests'
                     }
                 }
 


### PR DESCRIPTION
Without it, the deploy fails as maven provided by docker doesn't have the right credentials