### PR TITLE
bump CouchDB entity version to 1.7.2

### DIFF
--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/couchdb/CouchDBNode.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/couchdb/CouchDBNode.java
@@ -46,7 +46,7 @@ public interface CouchDBNode extends SoftwareProcess, WebAppService {
     ConfigKey<String> ARCHIVE_DIRECTORY_NAME_FORMAT = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.ARCHIVE_DIRECTORY_NAME_FORMAT, "apache-couchdb-%s");
     
     @SetFromFlag("version")
-    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "1.6.1");
+    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "1.7.2");
 
     @SetFromFlag("erlangVersion")
     ConfigKey<String> ERLANG_VERSION = ConfigKeys.newStringConfigKey("erlang.version", "Erlang runtime version", "R15B");


### PR DESCRIPTION
At the CouchDB download url (http://www.mirrorservice.org/sites/ftp.apache.org/couchdb/source/), the only versions currently available are 1.7.2, 2.1.2 and 2.2.0.

Have tested this with 1.7.2 (on CentOS 7, in aws, gce, arm and vexxhost).