### PR TITLE
Jenkins docker: use non-root user

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,16 +36,16 @@ node(label: 'ubuntu') {
             }
 
             stage('Run tests') {
-                environmentDockerImage.inside('-i --name brooklyn-${DOCKER_TAG} -v ${WORKSPACE}/.m2:/root/.m2 -v ${WORKSPACE}:/usr/build -w /usr/build') {
-                    sh 'mvn clean install'
+                environmentDockerImage.inside('-i --name brooklyn-${DOCKER_TAG} -u 910:910 -v ${WORKSPACE}/.m2:/var/maven/.m2 -v ${WORKSPACE}:/usr/build -w /usr/build -e MAVEN_CONFIG=/var/maven/.m2') {
+                    sh 'mvn clean install -Duser.name=$(id -un 910)'
                 }
             }
 
             // Conditional stage to deploy artifacts, when not building a PR
             if (env.CHANGE_ID == null) {
                 stage('Deploy artifacts') {
-                    environmentDockerImage.inside('-i --name brooklyn-${DOCKER_TAG} -v ${WORKSPACE}/.m2:/root/.m2 -v ${WORKSPACE}:/usr/build -w /usr/build') {
-                        sh 'mvn deploy -DskipTests'
+                    environmentDockerImage.inside('-i --name brooklyn-${DOCKER_TAG} -u 910:910 -v ${WORKSPACE}/.m2:/var/maven/.m2 -v ${WORKSPACE}:/usr/build -w /usr/build -e MAVEN_CONFIG=/var/maven/.m2') {
+                        sh 'mvn deploy -DskipTests -Duser.name=$(id -un 910)'
                     }
                 }
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,10 @@ docker build -t brooklyn:library .
 Then run the build:
 
 ```bash
-docker run -i --rm --name brooklyn-library -v ${HOME}/.m2:/root/.m2 -v ${PWD}:/usr/build -w /usr/build brooklyn:library mvn clean install
+docker run -i --rm --name brooklyn-library -u $(id -u $(whoami)):$(id -g $(whoami)) \
+    -e MAVEN_CONFIG=/var/maven/.m2 \
+    -v ${HOME}/.m2:/var/maven/.m2 -v ${PWD}:/usr/build -w /usr/build \
+    brooklyn:library mvn clean install -Duser.home=/var/maven -Duser.name=$(whoami)
 ```
 
 ### Using maven


### PR DESCRIPTION
Implementing part of the advice from infra in https://issues.apache.org/jira/browse/INFRA-16417

---
They advised we use `-u 910:910`, rather than the mvn command running as root in the container. 

Note that running the docker build on my local (mac) laptop, the user ids are interesting! In the container, (which use bind mounts for `.m2` and and the workspace) are owned by root:root. However, on my laptop, the files created are still owned by my own user.

Magic?! I'm therefore not sure whether this change will make much difference.

---
The other big change we need (not done here - I'll look at that next), recommended in INFRA-16417, is to STOP bind mounting .m2. They said: "Please don't use a bind mount for filesystems you intend to write to".