### PR TITLE
jenkins: don't bind mount .m2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,3 +19,7 @@ FROM maven:3.5.4-jdk-8-alpine
 
 # Install necessary binaries to build brooklyn-library
 RUN apk add --no-cache git procps
+
+RUN mkdir -p /var/maven/.m2/ && chmod -R 777 /var/maven/
+ENV MAVEN_CONFIG=/var/maven/.m2
+

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -36,16 +36,16 @@ node(label: 'ubuntu') {
             }
 
             stage('Run tests') {
-                environmentDockerImage.inside('-i --name brooklyn-${DOCKER_TAG} -u 910:910 -v ${WORKSPACE}/.m2:/var/maven/.m2 -v ${WORKSPACE}:/usr/build -w /usr/build -e MAVEN_CONFIG=/var/maven/.m2') {
-                    sh 'mvn clean install -Duser.name=$(id -un 910)'
+                environmentDockerImage.inside('-i --name brooklyn-${DOCKER_TAG} -u 910:910 --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly -v ${WORKSPACE}:/usr/build -w /usr/build') {
+                    sh 'mvn clean install -Duser.home=/var/maven -Duser.name=$(id -un 910)'
                 }
             }
 
             // Conditional stage to deploy artifacts, when not building a PR
             if (env.CHANGE_ID == null) {
                 stage('Deploy artifacts') {
-                    environmentDockerImage.inside('-i --name brooklyn-${DOCKER_TAG} -u 910:910 -v ${WORKSPACE}/.m2:/var/maven/.m2 -v ${WORKSPACE}:/usr/build -w /usr/build -e MAVEN_CONFIG=/var/maven/.m2') {
-                        sh 'mvn deploy -DskipTests -Duser.name=$(id -un 910)'
+                    environmentDockerImage.inside('-i --name brooklyn-${DOCKER_TAG} -u 910:910 -v ${WORKSPACE}:/usr/build -w /usr/build') {
+                        sh 'mvn deploy -DskipTests -Duser.home=/var/maven -Duser.name=$(id -un 910)'
                     }
                 }
 

--- a/README.md
+++ b/README.md
@@ -4,12 +4,20 @@
 ### Library of Entities for Apache Brooklyn
 
 This sub-project contains various entities not *needed* for Brooklyn,
-but useful in practice as building blocks, including entities for webapps,
+but useful as building blocks, including entities for webapps,
 datastores, and more.
 
 ### Building the project
 
-2 methods are available to build this project: within a docker container or directly with maven.
+Two methods are available to build this project: within a docker container or directly with maven.
+
+#### Using maven
+
+Simply run:
+
+```bash
+mvn clean install
+```
 
 #### Using docker
 
@@ -23,16 +31,18 @@ docker build -t brooklyn:library .
 Then run the build:
 
 ```bash
-docker run -i --rm --name brooklyn-library -u $(id -u $(whoami)):$(id -g $(whoami)) \
-    -e MAVEN_CONFIG=/var/maven/.m2 \
-    -v ${HOME}/.m2:/var/maven/.m2 -v ${PWD}:/usr/build -w /usr/build \
-    brooklyn:library mvn clean install -Duser.home=/var/maven -Duser.name=$(whoami)
+docker run -i --rm --name brooklyn-library -u $(id -u):$(id -g) \
+     --mount type=bind,source="${HOME}/.m2/settings.xml",target=/var/maven/.m2/settings.xml,readonly \
+     -v ${PWD}:/usr/build -w /usr/build \
+     brooklyn:library mvn clean install -Duser.home=/var/maven -Duser.name=$(id -un)
+
 ```
 
-### Using maven
-
-Simply run:
-
-```bash
-mvn clean install
+You can speed this up by using your local .m2 cache:
 ```
+docker run -i --rm --name brooklyn-library -u $(id -u):$(id -g) \
+    -v ${HOME}/.m2:/var/maven/.m2 \
+    -v ${PWD}:/usr/build -w /usr/build \
+    brooklyn:library mvn clean install -Duser.home=/var/maven -Duser.name=$(id -un)
+```
+

--- a/software/webapp/pom.xml
+++ b/software/webapp/pom.xml
@@ -48,6 +48,7 @@
                             -->
                             <exclude>src/main/resources/org/apache/brooklyn/entity/webapp/jboss/jboss7-standalone.xml</exclude>
                             <exclude>src/main/resources/org/apache/brooklyn/entity/webapp/jetty/jetty-brooklyn.xml</exclude>
+                            <exclude>**/.brooklyn/brooklyn-persisted-state/**</exclude>
                         </excludes>
                     </configuration>
                 </plugin>


### PR DESCRIPTION
As per the recommendations from Apache Infra in INFRA-16417 (comments [1] and [2]).

[1] https://issues.apache.org/jira/browse/INFRA-16417?focusedCommentId=16452458&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16452458
[2] https://issues.apache.org/jira/browse/INFRA-16417?focusedCommentId=16466275&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16466275

---
This will make the jenkins build a bit slower (downloading all of the .m2 cache each time), but should fix the permissions errors we've been seeing.