### PR TITLE
change MariaDB mirror site and bump patch version

### DIFF
--- a/software/database/src/main/java/org/apache/brooklyn/entity/database/mariadb/MariaDbNode.java
+++ b/software/database/src/main/java/org/apache/brooklyn/entity/database/mariadb/MariaDbNode.java
@@ -42,7 +42,7 @@ public interface MariaDbNode extends SoftwareProcess, DatastoreCommon, HasShortN
 
     @SetFromFlag("version")
     public static final ConfigKey<String> SUGGESTED_VERSION =
-        ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "10.2.6");
+        ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "10.2.21");
 
     // https://downloads.mariadb.org/interstitial/mariadb-5.5.33a/kvm-bintar-hardy-amd64/mariadb-5.5.33a-linux-x86_64.tar.gz/from/http://mirrors.coreix.net/mariadb
     // above redirects to download the artifactd from the URLs below.
@@ -57,7 +57,7 @@ public interface MariaDbNode extends SoftwareProcess, DatastoreCommon, HasShortN
     /** download mirror, if desired */
     @SetFromFlag("mirrorUrl")
     public static final ConfigKey<String> MIRROR_URL = ConfigKeys.newStringConfigKey("mariadb.install.mirror.url", "URL of mirror",
-        "http://ftp.hosteurope.de/mirror/archive.mariadb.org"
+        "http://mirrors.coreix.net/mariadb/"
      );
 
     @SetFromFlag("port")


### PR DESCRIPTION
the old mirror seems to blacklist AWS, but this mirror works fine