### PR TITLE
Postgresql version change from 9.3 to 10 

### DIFF
--- a/software/database/src/main/java/org/apache/brooklyn/entity/database/postgresql/PostgreSqlNode.java
+++ b/software/database/src/main/java/org/apache/brooklyn/entity/database/postgresql/PostgreSqlNode.java
@@ -52,7 +52,7 @@ import java.util.Map;
 public interface PostgreSqlNode extends SoftwareProcess, HasShortName, DatastoreCommon, DatabaseNode {
     
     @SetFromFlag("version")
-    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "9.3-3");//"9.1-4");
+    ConfigKey<String> SUGGESTED_VERSION = ConfigKeys.newConfigKeyWithDefault(SoftwareProcess.SUGGESTED_VERSION, "10-10-2");//"9.1-4");
 
     @SetFromFlag("configFileUrl")
     ConfigKey<String> CONFIGURATION_FILE_URL = ConfigKeys.newStringConfigKey(


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/165526205
brooklyn-postgresql-java test was failing due to incorrect download url. 
Since ver 9.3 is no longer maintained it was not possible to obtain a current url for Centos 7 so the version was changed to 10.
PostgreSql tests passing, however Integration tests did not work even before this change.