### PR TITLE
old java cassandra blueprints deprecated

### DIFF
--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraDatacenter.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraDatacenter.java
@@ -44,17 +44,10 @@ import com.google.common.collect.Multimap;
 import com.google.common.reflect.TypeToken;
 
 /**
- * A group of {@link CassandraNode}s -- based on Brooklyn's {@link DynamicCluster} 
- * (though it is a "Datacenter" in Cassandra terms, where Cassandra's "cluster" corresponds
- * to a Brooklyn Fabric, cf {@link CassandraFabric}). 
- * The Datacenter can be resized, manually or by policy if required.
- * Tokens are selected intelligently.
- * <p>
- * Note that due to how Cassandra assumes ports are the same across a cluster,
- * it is <em>NOT</em> possible to deploy a cluster of size larger than 1 to localhost.
- * (Some exploratory work has been done to use different 127.0.0.x IP's for localhost,
- * and there is evidence this could be made to work.)
+ * @deprecated since 1.0.0; use {@link 'https://github.com/brooklyncentral/brooklyn-cassandra'} which is a pure YAML template
+ * for a database cluster.
  */
+@Deprecated
 @Catalog(name="Apache Cassandra Datacenter Cluster", description="Cassandra is a highly scalable, eventually " +
         "consistent, distributed, structured key-value store which provides a ColumnFamily-based data model " +
         "richer than typical key/value systems", iconUrl="classpath:///cassandra-logo.jpeg")

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraDatacenterImpl.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraDatacenterImpl.java
@@ -70,14 +70,10 @@ import com.google.common.collect.Sets;
 import com.google.common.net.HostAndPort;
 
 /**
- * Implementation of {@link CassandraDatacenter}.
- * <p>
- * Several subtleties to note:
- * - a node may take some time after it is running and serving JMX to actually be contactable on its thrift port
- *   (so we wait for thrift port to be contactable)
- * - sometimes new nodes take a while to peer, and/or take a while to get a consistent schema
- *   (each up to 1m; often very close to the 1m) 
+ * @deprecated since 1.0.0; use {@link 'https://github.com/brooklyncentral/brooklyn-cassandra'} which is a pure YAML template
+ * for a database cluster.
  */
+@Deprecated
 public class CassandraDatacenterImpl extends DynamicClusterImpl implements CassandraDatacenter {
 
     /*

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraFabric.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraFabric.java
@@ -36,11 +36,10 @@ import com.google.common.collect.Multimap;
 import com.google.common.reflect.TypeToken;
 
 /**
- * A fabric of {@link CassandraNode}s, which forms a cluster spanning multiple locations.
- * <p>
- * Each {@link CassandraDatacenter} child instance is actually just a part of the whole cluster. It consists of the
- * nodes in that single location (which normally corresponds to a "datacenter" in Cassandra terminology).
+ * @deprecated since 1.0.0; use {@link 'https://github.com/brooklyncentral/brooklyn-cassandra'} which is a pure YAML template
+ * for a database cluster.
  */
+@Deprecated
 @Catalog(name="Apache Cassandra Database Fabric", description="Cassandra is a highly scalable, eventually " +
         "consistent, distributed, structured key-value store which provides a ColumnFamily-based data model " +
         "richer than typical key/value systems", iconUrl="classpath:///cassandra-logo.jpeg")

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraFabricImpl.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraFabricImpl.java
@@ -56,14 +56,10 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 
 /**
- * Implementation of {@link CassandraDatacenter}.
- * <p>
- * Serveral subtleties to note:
- * - a node may take some time after it is running and serving JMX to actually be contactable on its thrift port
- *   (so we wait for thrift port to be contactable)
- * - sometimes new nodes take a while to peer, and/or take a while to get a consistent schema
- *   (each up to 1m; often very close to the 1m) 
+ * @deprecated since 1.0.0; use {@link 'https://github.com/brooklyncentral/brooklyn-cassandra'} which is a pure YAML template
+ * for a database cluster.
  */
+@Deprecated
 public class CassandraFabricImpl extends DynamicFabricImpl implements CassandraFabric {
 
     private static final Logger log = LoggerFactory.getLogger(CassandraFabricImpl.class);

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraNode.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraNode.java
@@ -44,8 +44,10 @@ import org.apache.brooklyn.util.core.flags.SetFromFlag;
 import org.apache.brooklyn.util.time.Duration;
 
 /**
- * An {@link org.apache.brooklyn.api.entity.Entity} that represents a Cassandra node in a {@link CassandraDatacenter}.
+ * @deprecated since 1.0.0; use {@link 'https://github.com/brooklyncentral/brooklyn-cassandra'} which is a pure YAML template
+ * for a database cluster.
  */
+@Deprecated
 @Catalog(name="Apache Cassandra Node", description="Cassandra is a highly scalable, eventually " +
         "consistent, distributed, structured key-value store which provides a ColumnFamily-based data model " +
         "richer than typical key/value systems", iconUrl="classpath:///cassandra-logo.jpeg")

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraNodeDriver.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraNodeDriver.java
@@ -20,7 +20,11 @@ package org.apache.brooklyn.entity.nosql.cassandra;
 
 import org.apache.brooklyn.entity.java.JavaSoftwareProcessDriver;
 import org.apache.brooklyn.util.core.task.system.ProcessTaskWrapper;
-
+/**
+ * @deprecated since 1.0.0; use {@link 'https://github.com/brooklyncentral/brooklyn-cassandra'} which is a pure YAML template
+ * for a database cluster.
+ */
+@Deprecated
 public interface CassandraNodeDriver extends JavaSoftwareProcessDriver {
 
     Integer getGossipPort();

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraNodeImpl.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraNodeImpl.java
@@ -81,8 +81,10 @@ import com.google.common.collect.Sets;
 import com.google.common.net.HostAndPort;
 
 /**
- * Implementation of {@link CassandraNode}.
+ * @deprecated since 1.0.0; use {@link 'https://github.com/brooklyncentral/brooklyn-cassandra'} which is a pure YAML template
+ * for a database cluster.
  */
+@Deprecated
 public class CassandraNodeImpl extends SoftwareProcessImpl implements CassandraNode {
 
     private static final Logger log = LoggerFactory.getLogger(CassandraNodeImpl.class);

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraNodeSshDriver.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/CassandraNodeSshDriver.java
@@ -65,8 +65,10 @@ import org.apache.brooklyn.util.time.Duration;
 import org.apache.brooklyn.util.time.Time;
 
 /**
- * Start a {@link CassandraNode} in a {@link Location} accessible over ssh.
+ * @deprecated since 1.0.0; use {@link 'https://github.com/brooklyncentral/brooklyn-cassandra'} which is a pure YAML template
+ * for a database cluster.
  */
+@Deprecated
 public class CassandraNodeSshDriver extends JavaSoftwareProcessSshDriver implements CassandraNodeDriver {
 
     private static final Logger log = LoggerFactory.getLogger(CassandraNodeSshDriver.class);

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/TokenGenerator.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/TokenGenerator.java
@@ -20,7 +20,11 @@ package org.apache.brooklyn.entity.nosql.cassandra;
 
 import java.math.BigInteger;
 import java.util.Set;
-
+/**
+ * @deprecated since 1.0.0; use {@link 'https://github.com/brooklyncentral/brooklyn-cassandra'} which is a pure YAML template
+ * for a database cluster.
+ */
+@Deprecated
 public interface TokenGenerator {
 
     BigInteger max();

--- a/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/TokenGenerators.java
+++ b/software/nosql/src/main/java/org/apache/brooklyn/entity/nosql/cassandra/TokenGenerators.java
@@ -32,7 +32,11 @@ import org.apache.brooklyn.util.collections.MutableList;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
-
+/**
+ * @deprecated since 1.0.0; use {@link 'https://github.com/brooklyncentral/brooklyn-cassandra'} which is a pure YAML template
+ * for a database cluster.
+ */
+@Deprecated
 public class TokenGenerators {
 
     /**


### PR DESCRIPTION
These java blueprints use Cassandra 1.2.16 (current vers 3.11) An alternative YAML blueprint is available https://github.com/brooklyncentral/brooklyn-cassandra