### PR TITLE
Fixes ansible runAnsible task

### DIFF
--- a/software/cm/ansible/src/main/java/org/apache/brooklyn/entity/cm/ansible/AnsiblePlaybookTasks.java
+++ b/software/cm/ansible/src/main/java/org/apache/brooklyn/entity/cm/ansible/AnsiblePlaybookTasks.java
@@ -71,7 +71,7 @@ public class AnsiblePlaybookTasks {
     public static TaskFactory<?> runAnsible(final String dir, Object extraVars, String playbookName) {
         String cmd = sudo(String.format("ansible-playbook "
             + optionalExtraVarsParameter(extraVars)
-            + " -s %s.yaml", playbookName));
+            + " -b %s.yaml", playbookName));
 
         if (LOG.isDebugEnabled()) {
             LOG.debug("Ansible command: {}", cmd);


### PR DESCRIPTION
Replaces the deprecated, and now removed `-s` option on `ansible-playbook` with `-b`

See https://docs.ansible.com/ansible/2.7/cli/ansible-playbook.html