### PR TITLE
Fixed API for KnifeTaskFactory by replacing guava.Function with java.…

### DIFF
--- a/software/cm/chef/src/main/java/org/apache/brooklyn/entity/chef/KnifeConvergeTaskFactory.java
+++ b/software/cm/chef/src/main/java/org/apache/brooklyn/entity/chef/KnifeConvergeTaskFactory.java
@@ -39,7 +39,7 @@ import org.apache.brooklyn.util.collections.MutableMap;
 import org.apache.brooklyn.util.core.task.system.ProcessTaskWrapper;
 import org.apache.brooklyn.util.ssh.BashCommands;
 
-import com.google.common.base.Function;
+import java.util.function.Function;
 import com.google.common.base.Functions;
 import com.google.gson.GsonBuilder;
 

--- a/software/cm/chef/src/main/java/org/apache/brooklyn/entity/chef/KnifeTaskFactory.java
+++ b/software/cm/chef/src/main/java/org/apache/brooklyn/entity/chef/KnifeTaskFactory.java
@@ -35,7 +35,7 @@ import org.apache.brooklyn.util.core.task.system.internal.SystemProcessTaskFacto
 import org.apache.brooklyn.util.text.Strings;
 import org.apache.brooklyn.util.text.StringEscapes.BashStringEscapes;
 
-import com.google.common.base.Function;
+import java.util.function.Function;
 
 /** A factory which acts like {@link ProcessTaskFactory} with special options for knife.
  * Typical usage is to {@link #addKnifeParameters(String)}s for the knife command to be run.


### PR DESCRIPTION
Fixed API for KnifeTaskFactory by replacing `com.google.common.base.Function` with `java.util.function.Function`.